### PR TITLE
Adding a wraper for DBSCAN clustering

### DIFF
--- a/freediscovery/api/resources.py
+++ b/freediscovery/api/resources.py
@@ -348,7 +348,11 @@ class ClusteringApiElement(Resource):
         htree = cl._get_htree(km)
         if 'children' in htree:
             htree['children'] = htree['children'].tolist()
-        terms = cl.compute_labels(**args)
+        if args['n_top_words'] > 0:
+            terms = cl.compute_labels(**args)
+        else:
+            terms = []
+
         pars = cl._load_pars()
         if pars['lsi']:
             pars['lsi'] = True


### PR DESCRIPTION
This PR adds a wrapper for DBSCAN clustering.

This algorithm can also be used to benchmark duplicate detection (i.e. mark as duplicates documents based on some cosine distance threshold).

**Edit:** note that the `eps` parameter in DBSCAN corresponds to `2*cosine_distance`, when features are L2 normalized.