### PR TITLE
Mechanism for downloading and loading benchmark datasets

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,18 +30,12 @@ script:
     # now start the server and run the examples
     - | 
         mkdir -p ../freediscovery_shared;
-        if [ ! -f "../freediscovery_shared/treclegal09_2k_subset.tar.gz" ]; then
-            curl "http://r0h.eu/d/treclegal09_2k_subset.tar.gz" -L -o "../freediscovery_shared/treclegal09_2k_subset.tar.gz"
-            cd ../freediscovery_shared && tar xzf treclegal09_2k_subset.tar.gz && cd -
-        fi
-    - |
         python scripts/run_api.py ../freediscovery_shared &
         FDSERVER_PID=$!
         sleep 20  
     - | 
         cd examples/
         for f in ./*example*.py; do python $f ; done
-
 
 #after_success:
 #    coveralls

--- a/.travis.yml
+++ b/.travis.yml
@@ -35,7 +35,11 @@ script:
         sleep 20  
     - | 
         cd examples/
-        for f in ./*example*.py; do python $f ; done
+        set -o pipefail
+        for f in ./*example*.py; do 
+           python $f >> log.txt
+        done
+        cat log.txt && if grep -q "Traceback (most recent call last):" ~/log.txt; then false; else true; fi
 
 #after_success:
 #    coveralls

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -38,8 +38,6 @@ install:
   - "pip install -r .\\build_tools\\requirements_pip_win.txt"
   - python setup.py develop 
 
-
-
 test_script:
   - activate freediscovery-env # activate the virtualenv
   - "cd C:\\projects\\freediscovery\\freediscovery\\tests" # just to avoid full relative path in py.test
@@ -50,14 +48,6 @@ test_script:
 #  - ps: |
 #        if (!(Test-Path -Path "freediscovery_shared")) {
 #            New-Item -ItemType directory -Path "freediscovery_shared"
-#        }
-#        conda install -c anaconda curl=7.49.0
-#        if (!(Test-Path -Path "freediscovery_shared\\treclegal09_2k_subset.tar.gz")) {
-#            Remove-item alias:curl # https://stackoverflow.com/questions/25044010/running-curl-on-64-bit-windows
-#            cd "freediscovery_shared"
-#            curl "http://r0h.eu/d/treclegal09_2k_subset.tar.gz" -L -o "treclegal09_2k_subset.tar.gz"
-#            tar xzf treclegal09_2k_subset.tar.gz
-#            cd -
 #        }
 #  - START /B python scripts/run_api.py "freediscovery_shared"
 #  - ps: |

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -42,17 +42,15 @@ test_script:
   - activate freediscovery-env # activate the virtualenv
   - "cd C:\\projects\\freediscovery\\freediscovery\\tests" # just to avoid full relative path in py.test
   - python -c "import freediscovery.tests as ft; ft.run_cli()"
-# Running the examples on windows is not working yet
-# This should be easier after #9 is implemented
-#  - "cd C:\\projects\\freediscovery"
-#  - ps: |
-#        if (!(Test-Path -Path "freediscovery_shared")) {
-#            New-Item -ItemType directory -Path "freediscovery_shared"
-#        }
-#  - START /B python scripts/run_api.py "freediscovery_shared"
-#  - ps: |
-#        cd ".\\examples"
-#        Get-ChildItem ".\\" -Filter *.py | 
-#        Foreach-Object {
-#            python $_.FullName
-#        }
+  - "cd C:\\projects\\freediscovery"
+  - ps: |
+        if (!(Test-Path -Path ".\\freediscovery_shared")) {
+            New-Item -ItemType directory -Path ".\\freediscovery_shared"
+        }
+  - ps: Start-Process -FilePath "python" -ArgumentList "scripts\\run_api.py freediscovery_shared" -WorkingDirectory ".\\"
+  - ps: |
+        cd ".\\examples"
+        Get-ChildItem ".\\" -Filter *.py | 
+        Foreach-Object {
+            python $_.FullName
+        }

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -52,5 +52,6 @@ test_script:
         cd ".\\examples"
         Get-ChildItem ".\\" -Filter *.py | 
         Foreach-Object {
-            python $_.FullName
+            python $_.FullName 2>&1 | Tee-Object -Append -FilePath "log.txt"
         }
+

--- a/build_tools/circle/build_doc.sh
+++ b/build_tools/circle/build_doc.sh
@@ -43,8 +43,3 @@ python setup.py develop
 
 # start the FreeDiscovery server in the background
 mkdir -p ../freediscovery_shared
-
-if [ ! -f "../freediscovery_shared/treclegal09_2k_subset.tar.gz" ]; then
-    curl "http://r0h.eu/d/treclegal09_2k_subset.tar.gz" -L -o "../freediscovery_shared/treclegal09_2k_subset.tar.gz"
-    cd ../freediscovery_shared && tar xzf treclegal09_2k_subset.tar.gz && cd -
-fi

--- a/build_tools/requirements_conda.txt
+++ b/build_tools/requirements_conda.txt
@@ -6,3 +6,4 @@ numpy==1.11.1
 scipy==0.18
 pandas==0.18.1
 flask==0.11
+requests==2.11.1

--- a/build_tools/requirements_extra_pip.txt
+++ b/build_tools/requirements_extra_pip.txt
@@ -1,8 +1,5 @@
-requests
 matplotlib
-jupyter
 sphinx
 recommonmark
 sphinxcontrib-napoleon
 sphinx_rtd_theme
-

--- a/circle.yml
+++ b/circle.yml
@@ -9,7 +9,6 @@ dependencies:
     - python scripts/run_api.py ../freediscovery_shared:
        background: true
     - sleep 20
-    - cat nohup.out
     # The pipefail is requested to propagate exit code
     - set -o pipefail && cd doc && make html 2>&1 | tee ~/log.txt
 

--- a/conda_run.sh
+++ b/conda_run.sh
@@ -3,15 +3,6 @@
 export FD_CACHE_DIR="$(cd "../$(dirname .)"; pwd)/freediscovery_shared/"
 mkdir -p ../freediscovery_shared
 
-
-echo "
-    Download the benchmark TAR dataset (only the first time)
-    "
-if [ ! -f "${FD_CACHE_DIR}treclegal09_2k_subset.tar.gz" ]; then
-    curl "http://r0h.eu/d/treclegal09_2k_subset.tar.gz" -L -o "${FD_CACHE_DIR}/treclegal09_2k_subset.tar.gz"
-    cd ${FD_CACHE_DIR} && tar xzf treclegal09_2k_subset.tar.gz && cd -
-fi
-
 echo "
 Starting FREEDiscovery Server $(tail -n 1 freediscovery/_version.py |  cut -d "=" -f2) ($(date))
     shared folder set to ${FD_CACHE_DIR}

--- a/doc/Makefile
+++ b/doc/Makefile
@@ -50,7 +50,7 @@ help:
 
 clean:
 	rm -rf $(BUILDDIR)/*
-	rm -rf auto_examples/
+	rm -rf examples/
 	rm -rf modules/generated/*
 
 

--- a/docker_run.sh
+++ b/docker_run.sh
@@ -3,15 +3,6 @@
 export FD_CACHE_DIR="$(cd "../$(dirname .)"; pwd)/freediscovery_shared/"
 mkdir -p ../freediscovery_shared
 
-
-echo "
-    Download the benchmark TAR dataset (only the first time)
-    "
-if [ ! -f "${FD_CACHE_DIR}treclegal09_2k_subset.tar.gz" ]; then
-    curl "http://r0h.eu/d/treclegal09_2k_subset.tar.gz" -L -o "${FD_CACHE_DIR}/treclegal09_2k_subset.tar.gz"
-    cd ${FD_CACHE_DIR} && tar xzf treclegal09_2k_subset.tar.gz && cd -
-fi
-
 echo "
 Starting FREEDiscovery Server $(tail -n 1 freediscovery/_version.py |  cut -d "=" -f2 ) ($(date))
     shared folder set to ${FD_CACHE_DIR}

--- a/examples/categorization_example.py
+++ b/examples/categorization_example.py
@@ -16,174 +16,177 @@ dataset_name = "treclegal09_2k_subset"     # see list of available datasets
 
 BASE_URL = "http://localhost:5001/api/v0"  # FreeDiscovery server URL
 
-print(" 0. Load the test dataset")
-url = BASE_URL + '/datasets/{}'.format(dataset_name)
-print(" POST", url)
-res = requests.get(url)
-res = res.json()
+if __name__ == '__main__':
 
-# To use a custom dataset, simply specify the following variables
-data_dir = res['data_dir']
-relevant_files = res['seed_relevant_files']
-non_relevant_files = res['seed_non_relevant_files']
-ground_truth_file = res['ground_truth_file']  # (optional)
-
-
-# 1. Feature extraction
-
-print("\n1.a Load dataset and initalize feature extraction")
-url = BASE_URL + '/feature-extraction'
-print(" POST", url)
-fe_opts = {'data_dir': data_dir,
-           'stop_words': 'None', 'chunk_size': 2000, 'n_jobs': -1,
-           'use_idf': 1, 'sublinear_tf': 1, 'binary': 0, 'n_features': 50001,
-           'analyzer': 'word', 'ngram_range': (1, 1), "norm": "l2"
-          }
-res = requests.post(url, json=fe_opts)
-
-dsid = res.json()['id']
-print("   => received {}".format(list(res.json().keys())))
-print("   => dsid = {}".format(dsid))
-
-print("\n1.b Start feature extraction (in the background)")
-
-# Make this call in a background process (there should be a better way of doing it)
-url = BASE_URL+'/feature-extraction/{}'.format(dsid)
-print(" POST", url)
-p = Process(target=requests.post, args=(url,))
-p.start()
-sleep(5.0) # wait a bit for the processing to start
-
-print('\n1.c Monitor feature extraction progress')
-url = BASE_URL+'/feature-extraction/{}'.format(dsid)
-print(" GET", url)
-
-t0 = time()
-while True:
+    print(" 0. Load the test dataset")
+    url = BASE_URL + '/datasets/{}'.format(dataset_name)
+    print(" POST", url)
     res = requests.get(url)
-    if res.status_code == 520:
-        p.terminate()
-        raise ValueError('Processing did not start')
-    elif res.status_code == 200:
-        break # processing finished
+    res = res.json()
+
+    # To use a custom dataset, simply specify the following variables
+    data_dir = res['data_dir']
+    relevant_files = res['seed_relevant_files']
+    non_relevant_files = res['seed_non_relevant_files']
+    ground_truth_file = res['ground_truth_file']  # (optional)
+
+
+    # 1. Feature extraction
+
+    print("\n1.a Load dataset and initalize feature extraction")
+    url = BASE_URL + '/feature-extraction'
+    print(" POST", url)
+    fe_opts = {'data_dir': data_dir,
+               'stop_words': 'None', 'chunk_size': 2000, 'n_jobs': -1,
+               'use_idf': 1, 'sublinear_tf': 1, 'binary': 0, 'n_features': 50001,
+               'analyzer': 'word', 'ngram_range': (1, 1), "norm": "l2"
+              }
+    res = requests.post(url, json=fe_opts)
+
+    dsid = res.json()['id']
+    print("   => received {}".format(list(res.json().keys())))
+    print("   => dsid = {}".format(dsid))
+
+    print("\n1.b Start feature extraction (in the background)")
+
+    # Make this call in a background process (there should be a better way of doing it)
+    url = BASE_URL+'/feature-extraction/{}'.format(dsid)
+    print(" POST", url)
+    p = Process(target=requests.post, args=(url,))
+    p.start()
+    sleep(5.0) # wait a bit for the processing to start
+
+    print('\n1.c Monitor feature extraction progress')
+    url = BASE_URL+'/feature-extraction/{}'.format(dsid)
+    print(" GET", url)
+
+    t0 = time()
+    while True:
+        res = requests.get(url)
+        if res.status_code == 520:
+            p.terminate()
+            raise ValueError('Processing did not start')
+        elif res.status_code == 200:
+            break # processing finished
+        data = res.json()
+        print('     ... {}k/{}k files processed in {:.1f} min'.format(
+                    data['n_samples_processed']//1000, data['n_samples']//1000, (time() - t0)/60.))
+        sleep(15.0)
+
+    p.terminate()  # just in case, should not be necessary
+
+
+    print("\n1.d. check the parameters of the extracted features")
+    url = BASE_URL + '/feature-extraction/{}'.format(dsid)
+    print(' GET', url)
+    res = requests.get(url)
+
     data = res.json()
-    print('     ... {}k/{}k files processed in {:.1f} min'.format(
-                data['n_samples_processed']//1000, data['n_samples']//1000, (time() - t0)/60.))
-    sleep(15.0)
-
-p.terminate()  # just in case, should not be necessary
+    print('\n'.join(['     - {}: {}'.format(key, val) for key, val in data.items() \
+                                                      if "filenames" not in key]))
 
 
-print("\n1.d. check the parameters of the extracted features")
-url = BASE_URL + '/feature-extraction/{}'.format(dsid)
-print(' GET', url)
-res = requests.get(url)
+    # 2. Document categorization with ML algorithms
 
-data = res.json()
-for key, val in data.items():
-    if key!='filenames':
-           print('     - {}: {}'.format(key, val))
+    print("\n2.a. Train the ML categorization model")
+    print("       {} relevant, {} non-relevant files".format(
+        len(relevant_files), len(non_relevant_files)))
+    url = BASE_URL + '/categorization/'
+    print(" POST", url)
+    print(' Training...')
 
+    res = requests.post(url,
+                        json={'relevant_filenames': relevant_files,
+                              'non_relevant_filenames': non_relevant_files,
+                              'dataset_id': dsid,
+                              'method': 'LogisticRegression',  # one of "LinearSVC", "LogisticRegression", 'xgboost'
+                              'cv': 0                          # Cross Validation
+                              })
 
-# 2. Document categorization with ML algorithms
+    data = res.json()
+    mid = data['id']
+    print(data.keys())
+    print('Failed!!!')
+    print("     => model id = {}".format(mid))
+    print('    => Training scores: MAP = {average_precision:.2f}, ROC-AUC = {roc_auc:.2f}'.format(**data))
 
-print("\n2.a. Train the ML categorization model")
-print("       {} relevant, {} non-relevant files".format(
-    len(relevant_files), len(non_relevant_files)))
-url = BASE_URL + '/categorization/'
-print(" POST", url)
+    print("\n2.b. Check the parameters used in the categorization model")
+    url = BASE_URL + '/categorization/{}'.format(mid)
+    print(" GET", url)
+    res = requests.get(url)
 
-res = requests.post(url,
-                    json={'relevant_filenames': relevant_files,
-                          'non_relevant_filenames': non_relevant_files,
-                          'dataset_id': dsid,
-                          'method': 'LogisticRegression',  # one of "LinearSVC", "LogisticRegression", 'xgboost'
-                          'cv': 0                          # Cross Validation
-                          })
+    data = res.json()
+    print('\n'.join(['     - {}: {}'.format(key, val) for key, val in data.items() \
+                                                      if "filenames" not in key]))
 
-data = res.json()
-mid = data['id']
-print("     => model id = {}".format(mid))
-print('    => Training scores: MAP = {average_precision:.2f}, ROC-AUC = {roc_auc:.2f}'.format(**data))
+    print("\n2.c Categorize the complete dataset with this model")
+    url = BASE_URL + '/categorization/{}/predict'.format(mid)
+    print(" GET", url)
+    res = requests.get(url)
+    prediction = res.json()['prediction']
 
-print("\n2.b. Check the parameters used in the categorization model")
-url = BASE_URL + '/categorization/{}'.format(mid)
-print(" GET", url)
-res = requests.get(url)
+    print("    => Predicting {} relevant and {} non relevant documents".format(
+        len(list(filter(lambda x: x>0, prediction))),
+        len(list(filter(lambda x: x<0, prediction)))))
 
-data = res.json()
-for key, val in data.items():
-    if "filenames" not in key:
-        print('     - {}: {}'.format(key, val))
+    print("\n2.d Test categorization accuracy")
+    print("         using {}".format(ground_truth_file))  
+    url = BASE_URL + '/categorization/{}/test'.format(mid)
+    print("POST", url)
+    res = requests.post(url, json={'ground_truth_filename': ground_truth_file})
 
-print("\n2.c Categorize the complete dataset with this model")
-url = BASE_URL + '/categorization/{}/predict'.format(mid)
-print(" GET", url)
-res = requests.get(url)
-prediction = res.json()['prediction']
-
-print("    => Predicting {} relevant and {} non relevant documents".format(
-    len(list(filter(lambda x: x>0, prediction))),
-    len(list(filter(lambda x: x<0, prediction)))))
-
-print("\n2.d Test categorization accuracy")
-print("         using {}".format(ground_truth_file))  
-url = BASE_URL + '/categorization/{}/test'.format(mid)
-print("POST", url)
-res = requests.post(url, json={'ground_truth_filename': ground_truth_file})
-
-data2 = res.json()
-print('    => Test scores: MAP = {average_precision:.2f}, ROC-AUC = {roc_auc:.2f}'.format(**data2))
+    data2 = res.json()
+    print('    => Test scores: MAP = {average_precision:.2f}, ROC-AUC = {roc_auc:.2f}'.format(**data2))
 
 
-# 3. Document categorization with LSI
+    # 3. Document categorization with LSI
 
-print("\n3.a. Calculate LSI")
+    print("\n3.a. Calculate LSI")
 
-url = BASE_URL + '/lsi/'
-print("POST", url)
+    url = BASE_URL + '/lsi/'
+    print("POST", url)
 
-n_components = 100
-res = requests.post(url,
-                    json={'n_components': n_components,
-                          'dataset_id': dsid
-                          })
+    n_components = 100
+    res = requests.post(url,
+                        json={'n_components': n_components,
+                              'dataset_id': dsid
+                              })
 
-data = res.json()
-lid = data['id']
-print('  => LSI model id = {}'.format(lid))
-print('  => SVD decomposition with {} dimensions explaining {:.2f} % variabilty of the data'.format(
-                        n_components, data['explained_variance']*100))
-print("\n3.b. Predict categorization with LSI")
+    data = res.json()
+    lid = data['id']
+    print('  => LSI model id = {}'.format(lid))
+    print('  => SVD decomposition with {} dimensions explaining {:.2f} % variabilty of the data'.format(
+                            n_components, data['explained_variance']*100))
+    print("\n3.b. Predict categorization with LSI")
 
-url = BASE_URL + '/lsi/{}/predict'.format(lid)
-print("POST", url)
-res = requests.post(url,
-                    json={'relevant_filenames': relevant_files,
-                          'non_relevant_filenames': non_relevant_files
-                          })
-data = res.json()
+    url = BASE_URL + '/lsi/{}/predict'.format(lid)
+    print("POST", url)
+    res = requests.post(url,
+                        json={'relevant_filenames': relevant_files,
+                              'non_relevant_filenames': non_relevant_files
+                              })
+    data = res.json()
 
-prediction = data['prediction']
+    prediction = data['prediction']
 
-print('    => Training scores: MAP = {average_precision:.2f}, ROC-AUC = {roc_auc:.2f}'.format(**data))
-
-
-print("\n3.c. Test categorization with LSI")
-url = BASE_URL + '/lsi/{}/test'.format(lid)
-print(" POST", url)
-
-res = requests.post(url,
-                    json={'relevant_filenames': relevant_files,
-                          'non_relevant_filenames': non_relevant_files,
-                          'ground_truth_filename': ground_truth_file
-                          })
-data2 = res.json()
-print('    => Test scores: MAP = {average_precision:.2f}, ROC-AUC = {roc_auc:.2f}'.format(**data2))
-
-pd.DataFrame({key: data[key] for key in data if 'prediction' in key or 'nearest' in key})
+    print('    => Training scores: MAP = {average_precision:.2f}, ROC-AUC = {roc_auc:.2f}'.format(**data))
 
 
-print("\n4.a Delete the extracted features")
-url = BASE_URL + '/feature-extraction/{}'.format(dsid)
-print(" DELETE", url)
+    print("\n3.c. Test categorization with LSI")
+    url = BASE_URL + '/lsi/{}/test'.format(lid)
+    print(" POST", url)
+
+    res = requests.post(url,
+                        json={'relevant_filenames': relevant_files,
+                              'non_relevant_filenames': non_relevant_files,
+                              'ground_truth_filename': ground_truth_file
+                              })
+    data2 = res.json()
+    print('    => Test scores: MAP = {average_precision:.2f}, ROC-AUC = {roc_auc:.2f}'.format(**data2))
+
+    pd.DataFrame({key: data[key] for key in data if 'prediction' in key or 'nearest' in key})
+
+
+    print("\n4.a Delete the extracted features")
+    url = BASE_URL + '/feature-extraction/{}'.format(dsid)
+    print(" DELETE", url)

--- a/examples/categorization_example.py
+++ b/examples/categorization_example.py
@@ -1,6 +1,6 @@
 """
-Binary Categorization Example
--------------------------------
+Categorization Example [REST API]
+---------------------------------
 
 An example to illustrate binary categorizaiton with FreeDiscovery
 """

--- a/examples/clustering_example.py
+++ b/examples/clustering_example.py
@@ -1,10 +1,10 @@
 """
-Document Clustering Example
----------------------------
+Clustering Example [REST API]
+-----------------------------
 
+Cluster documents into clusters
 """
 
-import os
 import numpy as np
 import pandas as pd
 from time import time
@@ -13,18 +13,6 @@ import requests
 pd.options.display.float_format = '{:,.3f}'.format
 
 
-def _parent_dir(path, n=0):
-    path = os.path.abspath(path)
-    if n == 0:
-        return path
-    else:
-        return os.path.dirname(_parent_dir(path, n=n-1))
-
-
-def _print_url(op, url):
-    print(' '*1, op, url) 
-    
-
 def repr_clustering(labels, terms):
     out = []
     for ridx, row in enumerate(terms):
@@ -32,25 +20,25 @@ def repr_clustering(labels, terms):
     out = pd.DataFrame(out).sort_values('N_documents', ascending=False)
     return out
 
-use_docker = False
-
-dataset_name = "treclegal09_2k_subset"
-    
-if use_docker:
-    data_dir = "/freediscovery_shared/{}".format(dataset_name)
-else:
-    data_dir = "../freediscovery_shared/{}".format(dataset_name)
-rel_data_dir = os.path.abspath("../../freediscovery_shared/{}".format(dataset_name)) # relative path between this file and the FreeDiscovery source folder
+dataset_name = "treclegal09_2k_subset"     # see list of available datasets
 
 BASE_URL = "http://localhost:5001/api/v0"  # FreeDiscovery server URL
 
+print(" 0. Load the test dataset")
+url = BASE_URL + '/datasets/{}'.format(dataset_name)
+print(" POST", url)
+res = requests.get(url)
+res = res.json()
+
+# To use a custom dataset, simply specify the following variables
+data_dir = res['data_dir']
 
 # # 1. Feature extraction (non hashed)
 
 print("\n1.a Load dataset and initalize feature extraction")
 url = BASE_URL + '/feature-extraction'
-_print_url("POST", url)
-fe_opts = {'data_dir': os.path.join(data_dir, 'data'),
+print(" POST", url)
+fe_opts = {'data_dir': data_dir,
            'stop_words': 'english', 'chunk_size': 2000, 'n_jobs': -1,
            'use_idf': 1, 'sublinear_tf': 1, 'binary': 0, 'n_features': 30001,
            'analyzer': 'word', 'ngram_range': (1, 1), "norm": "l2",
@@ -66,12 +54,12 @@ print("   => dsid = {}".format(dsid))
 print("\n1.b Run feature extraction")
 # progress status is available for the hashed version only
 url = BASE_URL+'/feature-extraction/{}'.format(dsid)
-_print_url("POST", url)
+print(" POST", url)
 res = requests.post(url)
 
 print("\n1.d. check the parameters of the extracted features")
 url = BASE_URL + '/feature-extraction/{}'.format(dsid)
-_print_url('GET', url)
+print(' GET', url)
 res = requests.get(url)
 
 data = res.json()
@@ -85,7 +73,7 @@ for key, val in data.items():
 print("\n2.a. Document clustering (LSI + K-means)")
 
 url = BASE_URL + '/clustering/k-mean/'
-_print_url("POST", url)
+print(" POST", url)
 t0 = time()
 res = requests.post(url,
                     json={'dataset_id': dsid,
@@ -99,7 +87,7 @@ print("     => model id = {}".format(mid))
 
 print("\n2.b. Computing cluster labels")
 url = BASE_URL + '/clustering/k-mean/{}'.format(mid)
-_print_url("POST", url)
+print(" POST", url)
 res = requests.get(url,
                    json={'n_top_words': 6
                          })
@@ -115,7 +103,7 @@ print(repr_clustering(np.array(data['labels']), data['cluster_terms']))
 print("\n2.a. Document clustering (LSI + Ward HC)")
 
 url = BASE_URL + '/clustering/ward_hc/'
-_print_url("POST", url)
+print(" POST", url)
 t0 = time()
 res = requests.post(url,
                     json={'dataset_id': dsid,
@@ -130,7 +118,7 @@ print("     => model id = {}".format(mid))
 
 print("\n2.b. Computing cluster labels")
 url = BASE_URL + '/clustering/ward_hc/{}'.format(mid)
-_print_url("POST", url)
+print("POST", url)
 res = requests.get(url,
                    json={'n_top_words': 6
                          })

--- a/examples/clustering_example.py
+++ b/examples/clustering_example.py
@@ -63,9 +63,8 @@ print(' GET', url)
 res = requests.get(url)
 
 data = res.json()
-for key, val in data.items():
-    if key!='filenames':
-           print('     - {}: {}'.format(key, val))
+print('\n'.join(['     - {}: {}'.format(key, val) for key, val in data.items() \
+                                                  if "filenames" not in key]))
 
 
 # # 2. Document Clustering (LSI + K-Means)

--- a/examples/clustering_example_python.py
+++ b/examples/clustering_example_python.py
@@ -20,7 +20,7 @@ cache_dir = '.'
 
 print("0. Load Dataset")
 
-ds = load_dataset(dataset_name)
+ds = load_dataset(dataset_name, cache_dir=cache_dir)
 
 
 print("\n1. Feature extraction (non hashed)\n")

--- a/examples/clustering_example_python.py
+++ b/examples/clustering_example_python.py
@@ -1,40 +1,39 @@
 """
-Document Clustering example (Python)
-------------------------------------
+Clustering Example [Python API]
+-------------------------------
 
-An example of clustering using Python API
+An example of clustering using the Python API
 """
 
 import pandas as pd
-from IPython.display import display
 from freediscovery.text import FeatureVectorizer
 from freediscovery.cluster import Clustering
 from freediscovery.utils import _silent
+from freediscovery.datasets import load_dataset
 from time import time
 
 pd.options.display.float_format = '{:,.3f}'.format
 
 dataset_name = "treclegal09_2k_subset"
-
-data_dir = "../freediscovery_shared/{}".format(dataset_name)
-examples_to_server_path = "../" # relative path between this file and the FreeDiscovery source folder
-
-BASE_URL = "http://localhost:5001/api/v0"  # FreeDiscovery server URL
+cache_dir = '.'
 
 
-# # 1. Feature extraction (non hashed)
+print("0. Load Dataset")
+
+ds = load_dataset(dataset_name)
+
+
+print("\n1. Feature extraction (non hashed)\n")
 
 n_features = 30000
-cache_dir = '/tmp/'
-
 fe = FeatureVectorizer(cache_dir=cache_dir)
-uuid = fe.preprocess("../"+data_dir+'/data',
+uuid = fe.preprocess(ds['data_dir'],
                      n_features=n_features, use_hashing=False,
                      use_idf=True, stop_words='english')
 uuid, filenames = fe.transform()
 
 
-# # 2. Document Clustering (LSI + K-Means)
+print("\n2. Document Clustering (LSI + K-Means)\n")
 
 cat = Clustering(cache_dir=cache_dir, dsid=uuid)
 
@@ -58,10 +57,10 @@ with _silent('stderr'): # ignore some deprecation warnings
 t1 = time()
 
 print('    .. computed in {:.1f}s'.format(t1 - t0))
-display(repr_clustering(labels, terms))
+print(repr_clustering(labels, terms))
 
 
-# # 3. Document Clustering (LSI + Ward Hierarchical Clustering)
+print('\n3. Document Clustering (LSI + Ward Hierarchical Clustering)\n')
 
 t0 = time()
 with _silent('stderr'): # ignore some deprecation warnings
@@ -73,4 +72,4 @@ with _silent('stderr'): # ignore some deprecation warnings
 t1 = time()
 
 print('    .. computed in {:.1f}s'.format(t1 - t0))
-display(repr_clustering(labels, terms))
+print(repr_clustering(labels, terms))

--- a/examples/duplicate_detection_example.py
+++ b/examples/duplicate_detection_example.py
@@ -57,9 +57,8 @@ print(' GET', url)
 res = requests.get(url)
 
 data = res.json()
-for key, val in data.items():
-    if key!='filenames':
-           print('     - {}: {}'.format(key, val))
+print('\n'.join(['     - {}: {}'.format(key, val) for key, val in data.items() \
+                                                  if "filenames" not in key]))
 
 
 # # 2. Duplicate detection by cosine similarity (DBSCAN)

--- a/examples/duplicate_detection_example.py
+++ b/examples/duplicate_detection_example.py
@@ -1,5 +1,5 @@
 """
-Document Clustering example
+Duplicate Detection Example
 ---------------------------
 
 Find duplicates in a text collection

--- a/examples/duplicate_detection_example.py
+++ b/examples/duplicate_detection_example.py
@@ -4,11 +4,14 @@ Duplicate Detection Example [REST API]
 
 Find near-duplicates in a text collection
 """
+from __future__ import print_function
+
+from time import time
+import sys
+import platform
 
 import numpy as np
-
 import pandas as pd
-from time import time
 import requests
 
 pd.options.display.float_format = '{:,.3f}'.format
@@ -124,6 +127,10 @@ labels_ = data['cluster_id']
 
 print('Found {} duplicates / {}'.format(len(labels_) - len(np.unique(labels_)), len(labels_)))
 
+
+if platform.system() == 'Windows':
+    print('Simhash-py is currently not installed on Windows')
+    sys.exit()
 
 print("\n3. Duplicate detection by Simhash")
 

--- a/examples/duplicate_detection_example.py
+++ b/examples/duplicate_detection_example.py
@@ -1,52 +1,37 @@
 """
-Duplicate Detection Example
----------------------------
+Duplicate Detection Example [REST API]
+--------------------------------------
 
-Find duplicates in a text collection
+Find near-duplicates in a text collection
 """
 
-import os
-import re
 import numpy as np
 
 import pandas as pd
-import sys
-import shutil
 from time import time
 import requests
 
 pd.options.display.float_format = '{:,.3f}'.format
 
-def _parent_dir(path, n=0):
-    path = os.path.abspath(path)
-    if n == 0:
-        return path
-    else:
-        return os.path.dirname(_parent_dir(path, n=n-1))
 
-def _print_url(op, url):
-    print(' '*1, op, url) 
+dataset_name = "treclegal09_2k_subset"     # see list of available datasets
 
-use_docker = False
+BASE_URL = "http://localhost:5001/api/v0"  # FreeDiscovery server URL
 
-dataset_name = "treclegal09_2k_subset"
+print(" 0. Load the test dataset")
+url = BASE_URL + '/datasets/{}'.format(dataset_name)
+print(" POST", url)
+res = requests.get(url)
+res = res.json()
 
-if use_docker:
-    data_dir = "/freediscovery_shared/{}".format(dataset_name)
-else:
-    data_dir = "../freediscovery_shared/{}".format(dataset_name)
-rel_data_dir = os.path.abspath("../../freediscovery_shared/{}".format(dataset_name)) # relative path between this file and the FreeDiscovery source folder
-
-
-BASE_URL = "http://localhost:5001/api/v0"  # FreeDiscovery local server URL
-
-
+# To use a custom dataset, simply specify the following variables
+data_dir = res['data_dir']
 # # 1. Feature extraction (non hashed)
 
 print("\n1.a Load dataset and initalize feature extraction")
 url = BASE_URL + '/feature-extraction'
-_print_url("POST", url)
-fe_opts = {'data_dir': os.path.join(data_dir, 'data'),
+print(" POST", url)
+fe_opts = {'data_dir': data_dir,
            'stop_words': 'english', 'chunk_size': 2000, 'n_jobs': -1,
            'use_idf': 1, 'sublinear_tf': 0, 'binary': 0, 'n_features': 30001,
            'analyzer': 'word', 'ngram_range': (1, 1), "norm": "l2",
@@ -63,12 +48,12 @@ print("   => dsid = {}".format(dsid))
 print("\n1.b Run feature extraction")
 # progress status is available for the hashed version only
 url = BASE_URL+'/feature-extraction/{}'.format(dsid)
-_print_url("POST", url)
+print(" POST", url)
 res = requests.post(url)
 
 print("\n1.d. check the parameters of the extracted features")
 url = BASE_URL + '/feature-extraction/{}'.format(dsid)
-_print_url('GET', url)
+print(' GET', url)
 res = requests.get(url)
 
 data = res.json()
@@ -79,10 +64,10 @@ for key, val in data.items():
 
 # # 2. Duplicate detection by cosine similarity (DBSCAN)
 
-print("\n2.a. Duplicate detection by cosine similarity (DBSCAN)")
+print("\n2. Duplicate detection by cosine similarity (DBSCAN)")
 
 url = BASE_URL + '/clustering/dbscan/'
-_print_url("POST", url)
+print(" POST", url)
 t0 = time()
 res = requests.post(url,
         json={'dataset_id': dsid,
@@ -95,9 +80,8 @@ data = res.json()
 mid  = data['id']
 print("     => model id = {}".format(mid))
 
-print("\n2.b. Computing cluster labels")
 url = BASE_URL + '/clustering/k-mean/{}'.format(mid)
-_print_url("POST", url)
+print(" POST", url)
 res = requests.get(url,
         json={'n_top_words': 0, # don't compute cluster labels
               }) 
@@ -110,13 +94,42 @@ labels_ = data['labels']
 
 print('Found {} duplicates / {}'.format(len(labels_) - len(np.unique(labels_)), len(labels_)))
 
+print("\n3. Duplicate detection by I-Match")
 
-# # 3. Duplicate detection by Simhash
+url = BASE_URL + '/duplicate-detection/'
+print(" POST", url)
+t0 = time()
+res = requests.post(url,
+        json={'dataset_id': dsid,
+              'method': 'i-match',
+              }) 
+
+data = res.json()
+mid  = data['id']
+print("     => model id = {}".format(mid))
+
+print('    .. computed in {:.1f}s'.format(time() - t0))
+
+
+url = BASE_URL + '/duplicate-detection/{}'.format(mid)
+print("GET", url)
+t0 = time()
+res = requests.get(url,
+        json={'n_rand_lexicons': 10,
+              'rand_lexicon_ratio': 0.9}) 
+data = res.json()
+t1 = time()
+print('    .. computed in {:.1f}s'.format(time() - t0))
+
+labels_ = data['cluster_id']
+
+print('Found {} duplicates / {}'.format(len(labels_) - len(np.unique(labels_)), len(labels_)))
+
 
 print("\n3. Duplicate detection by Simhash")
 
 url = BASE_URL + '/duplicate-detection/'
-_print_url("POST", url)
+print(" POST", url)
 t0 = time()
 res = requests.post(url,
         json={'dataset_id': dsid,
@@ -132,7 +145,7 @@ print('    .. computed in {:.1f}s'.format(time() - t0))
 
 
 url = BASE_URL + '/duplicate-detection/{}'.format(mid)
-_print_url("GET", url)
+print(" GET", url)
 t0 = time()
 res = requests.get(url,
         json={'distance': 1 }) 
@@ -144,34 +157,4 @@ labels_ = data['cluster_id']
 print('Found {} duplicates / {}'.format(len(labels_) - len(np.unique(labels_)), len(labels_)))
 
 
-print("\n3. Duplicate detection by I-Match")
-
-url = BASE_URL + '/duplicate-detection/'
-_print_url("POST", url)
-t0 = time()
-res = requests.post(url,
-        json={'dataset_id': dsid,
-              'method': 'i-match',
-              }) 
-
-data = res.json()
-mid  = data['id']
-print("     => model id = {}".format(mid))
-
-print('    .. computed in {:.1f}s'.format(time() - t0))
-
-
-url = BASE_URL + '/duplicate-detection/{}'.format(mid)
-_print_url("GET", url)
-t0 = time()
-res = requests.get(url,
-        json={'n_rand_lexicons': 10,
-              'rand_lexicon_ratio': 0.9}) 
-data = res.json()
-t1 = time()
-print('    .. computed in {:.1f}s'.format(time() - t0))
-
-labels_ = data['cluster_id']
-
-print('Found {} duplicates / {}'.format(len(labels_) - len(np.unique(labels_)), len(labels_)))
 

--- a/freediscovery/api/app.py
+++ b/freediscovery/api/app.py
@@ -17,7 +17,8 @@ from .resources import (FeaturesApi, FeaturesApiElement, LsiApi, ModelsApi,
                         ClusteringApiElement, KmeanClusteringApi,
                         BirchClusteringApi, WardHCClusteringApi,
                         DBSCANClusteringApi,
-                        DupDetectionApi, DupDetectionApiElement
+                        DupDetectionApi, DupDetectionApiElement,
+                        DatasetsApiElement
                         )
 
 
@@ -42,6 +43,7 @@ def fd_app(cache_dir):
 
     ## Actually setup the Api resource routing here
     for resource_el, url in [(FeaturesApi,          "/feature-extraction"),
+                             (DatasetsApiElement,   "/datasets/<name>"),
                              (FeaturesApiElement,   '/feature-extraction/<dsid>'),
                              (ModelsApi,            '/categorization/'),
                              (ModelsApiElement,     '/categorization/<mid>'),

--- a/freediscovery/api/resources.py
+++ b/freediscovery/api/resources.py
@@ -174,7 +174,7 @@ class LsiApiElementTest(Resource):
     @marshal_with(ClassificationScoresSchema())
     def post(self, mid, **args):
         lsi = LSI(self._cache_dir, mid=mid)
-        d_ref = parse_ground_truth_file(os.path.join(lsi.fe.dsid_dir, args["ground_truth_filename"]))
+        d_ref = parse_ground_truth_file(args["ground_truth_filename"])
         del args['ground_truth_filename']
         lsi_m, X_train, Y_train, Y_train_res, X_test, Y_test_res, res  = lsi.predict(
                 accumulate='nearest-max', **args) 
@@ -265,8 +265,7 @@ class ModelsApiTest(Resource):
         cat = Categorizer(self._cache_dir, mid=mid)
 
         y_res = cat.predict()
-        d_ref = parse_ground_truth_file(os.path.join(cat.fe.dsid_dir,
-                                                     args["ground_truth_filename"]))
+        d_ref = parse_ground_truth_file( args["ground_truth_filename"])
         res = classification_score(d_ref.index.values,
                                    d_ref.is_relevant.values,
                                    cat.fe._pars['filenames'], y_res)

--- a/freediscovery/api/resources.py
+++ b/freediscovery/api/resources.py
@@ -18,13 +18,26 @@ from ..io import parse_ground_truth_file
 from ..utils import classification_score
 from ..cluster import Clustering
 from .schemas import (IDSchema, FeaturesParsSchema,
-                      FeaturesSchema,
+                      FeaturesSchema, DatasetSchema,
                       LsiParsSchema, LsiPostSchema, LsiPredictSchema,
                       ClassificationScoresSchema,
                       CategorizationParsSchema, CategorizationPostSchema,
                       CategorizationPredictSchema, ClusteringSchema,
                       ErrorSchema, DuplicateDetectionSchema
                       )
+
+# ============================================================================ # 
+#                         Datasets download                                    #
+# ============================================================================ # 
+
+class DatasetsApiElement(Resource):
+
+    @marshal_with(DatasetSchema())
+    def get(self, name):
+        from ..datasets import load_dataset
+        res = load_dataset(name, self._cache_dir, verbose=True,
+                load_ground_truth=True, verify_checksum=False)
+        return res
 
 
 # Definine the response formatting schemas

--- a/freediscovery/api/schemas.py
+++ b/freediscovery/api/schemas.py
@@ -12,6 +12,13 @@ from marshmallow import Schema, fields
 # Occasionally the same class can be used for input validation
 # As webargs (used for input validation) is just a wrapper around marshmallow
 
+class DatasetSchema(Schema):
+    base_dir = fields.Str(required=True)
+    data_dir = fields.Str(required=True)
+    ground_truth_file = fields.Str()
+    seed_relevant_files = fields.List(fields.Str())
+    seed_non_relevant_files = fields.List(fields.Str())
+
 class IDSchema(Schema):
     id = fields.Str(required=True)
 

--- a/freediscovery/api/utils.py
+++ b/freediscovery/api/utils.py
@@ -1,0 +1,13 @@
+# -*- coding: utf-8 -*-
+
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+from __future__ import unicode_literals
+
+def _is_inside_docker():
+    """ An imperfect way of checking that the server is
+    running inside a Docker container"""
+
+    return os.path.exists('/freediscovery_shared/')
+

--- a/freediscovery/datasets.py
+++ b/freediscovery/datasets.py
@@ -1,0 +1,134 @@
+# -*- coding: utf-8 -*-
+
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+from __future__ import unicode_literals
+
+
+import os
+import sys
+import shutil
+import hashlib
+
+
+def load_dataset(name='treclegal09_2k_subset', cache_dir='/tmp',
+                 force=False, verbose=True,
+                 load_ground_truth=False, verify_checksum=True):
+    """
+    Download a benchmark dataset.
+
+    Currently the following datasets based on TREC 2009 legal collection
+    are suported:
+       - treclegal09_2k_subset  :   2 400 documents,   2 MB
+       - treclegal09_20k_subset :  20 000 documents,  20 MB
+       - treclegal09_37k_subset :  37 000 documents,  50 MB
+       - treclegal09            : 700 000 documents, 1.2 GB (not available for now)
+    The ground truth files for categorization are adapted from TAR Toolkit.
+
+    If you encounter any issues for downloads with this function,
+    you can also manually donwload and extract the requred dataset to `cache_dir` (the
+    download url is `http://r0h.eu/d/<name>.tar.gz`), then re-run this function to get
+    the required metadata.
+
+    Parameters
+    ----------
+    name : str, default='treclegal09_2k_subset'
+       the name of the dataset file to load
+    cache_dir : str, default='/tmp/'
+       root directory where to save the download
+    force : bool, default=False
+       download again if the dataset already exists.
+       Warning: this will remove previously downloaded files!
+    load_ground_truth : bool, default=False
+       parse the ground truth files present in the dataset
+    verbose : bool, default=False
+       print download progress
+    verify_checksum : bool, default=False
+       verify the checksum of the downloaded archive
+
+    Returns
+    -------
+
+    response: dict
+       a dictionary containing
+           - base_dir: str
+               path to the dataset folder
+    """
+    import tarfile
+    import requests
+
+    VALID_MD5SUM = {'treclegal09_2k_subset' : '8090cc55ac18fe5c4d5d53d82fc767a2',
+                    'treclegal09_20k_subset': '43a711897ce724e873bdbc47a374a57e',
+                    'treclegal09_37k_subset': '9fb6b7505871bbaee5a438de3b0f497c'}
+
+    DATASET_SIZE = {'treclegal09_2k_subset' : 2.8,
+                    'treclegal09_20k_subset': 20,
+                    'treclegal09_37k_subset': 50}
+
+    if name not in VALID_MD5SUM:
+        raise ValueError('Dataset name {} not known!'.format(name))
+
+
+    base_url = "http://r0h.eu/d/{}.tar.gz".format(name)
+
+    outdir = os.path.join(cache_dir, name)
+    fname = outdir + ".tar.gz"
+
+    if os.path.exists(outdir) and force:
+        shutil.rmtree(outdir)
+
+    # Download the the dataset if it doesn't exist
+    if not os.path.exists(outdir):
+
+        if verbose:
+            print('\nWaring: downloading dataset {} ({} MB) !'.format(name,
+                                        DATASET_SIZE[name]))
+        response = requests.get(base_url, stream=False, allow_redirects=True)
+        with open(fname, "wb") as fh:
+            for idx, chunk in enumerate(response.iter_content(chunk_size=1024)):
+                if chunk:
+                    fh.write(chunk)
+            if verbose:
+                print('\nFile {} downloaded!'.format(fname))
+
+        if verify_checksum:
+            # compute the md5 hash by chunks
+            with open(fname, 'rb') as fh:
+                block_size=2**20
+                md5 = hashlib.md5()
+                while True:
+                    data = fh.read(block_size)
+                    if not data:
+                        break
+                    md5.update(data)
+                hash_val = md5.hexdigest()
+            if hash_val != VALID_MD5SUM[name]:
+                raise IOError('Checksum failed for the dataset, this may be due'
+                              'to a corrupted download. Try running this function'
+                              'again with the `force=True` option.')
+
+        # extract the .tar.gz
+        with tarfile.open(fname, "r:gz") as tar:
+            tar.extractall(path=cache_dir)
+            if verbose:
+                print('Archive extracted!'.format(fname))
+
+    results = {'base_dir': outdir, 'data_dir': os.path.join(outdir, 'data')}
+
+    if load_ground_truth:
+        with open(os.path.join(outdir,'seed_relevant.txt'), 'rt') as fh:
+            relevant_files = [el.strip() for el in fh.readlines()]
+        results['seed_relevant_files'] = relevant_files
+
+        with open(os.path.join(outdir,'seed_non_relevant.txt'), 'rt') as fh:
+            non_relevant_files = [el.strip() for el in fh.readlines()]
+        results['seed_non_relevant_files'] = non_relevant_files
+        results['ground_truth_file'] = os.path.join(outdir, "ground_truth_file.txt")  
+
+    return results
+
+
+
+
+

--- a/freediscovery/datasets.py
+++ b/freediscovery/datasets.py
@@ -10,6 +10,7 @@ import os
 import sys
 import shutil
 import hashlib
+import platform
 
 
 def load_dataset(name='treclegal09_2k_subset', cache_dir='/tmp',
@@ -114,17 +115,27 @@ def load_dataset(name='treclegal09_2k_subset', cache_dir='/tmp',
             if verbose:
                 print('Archive extracted!'.format(fname))
 
+
+
     results = {'base_dir': outdir, 'data_dir': os.path.join(outdir, 'data')}
+
 
     if load_ground_truth:
         with open(os.path.join(outdir,'seed_relevant.txt'), 'rt') as fh:
             relevant_files = [el.strip() for el in fh.readlines()]
-        results['seed_relevant_files'] = relevant_files
 
         with open(os.path.join(outdir,'seed_non_relevant.txt'), 'rt') as fh:
             non_relevant_files = [el.strip() for el in fh.readlines()]
+
+        ground_truth_file = os.path.join(outdir, "ground_truth_file.txt")  
+
+        if platform.system() == 'Windows':
+            relevant_files = [el.replace('/', '\\') for el in relevant_files]
+            non_relevant_files = [el.replace('/', '\\') for el in non_relevant_files]
+
         results['seed_non_relevant_files'] = non_relevant_files
-        results['ground_truth_file'] = os.path.join(outdir, "ground_truth_file.txt")  
+        results['seed_relevant_files'] = relevant_files
+        results['ground_truth_file'] = ground_truth_file
 
     return results
 

--- a/freediscovery/datasets.py
+++ b/freediscovery/datasets.py
@@ -14,16 +14,16 @@ import hashlib
 
 def load_dataset(name='treclegal09_2k_subset', cache_dir='/tmp',
                  force=False, verbose=True,
-                 load_ground_truth=False, verify_checksum=True):
+                 load_ground_truth=False, verify_checksum=False):
     """
     Download a benchmark dataset.
 
     Currently the following datasets based on TREC 2009 legal collection
     are suported:
        - treclegal09_2k_subset  :   2 400 documents,   2 MB
-       - treclegal09_20k_subset :  20 000 documents,  20 MB
-       - treclegal09_37k_subset :  37 000 documents,  50 MB
-       - treclegal09            : 700 000 documents, 1.2 GB (not available for now)
+       - treclegal09_20k_subset :  20 000 documents,  30 MB
+       - treclegal09_37k_subset :  37 000 documents,  55 MB
+       - treclegal09            : 700 000 documents, 1.2 GB
     The ground truth files for categorization are adapted from TAR Toolkit.
 
     If you encounter any issues for downloads with this function,
@@ -63,8 +63,8 @@ def load_dataset(name='treclegal09_2k_subset', cache_dir='/tmp',
                     'treclegal09_37k_subset': '9fb6b7505871bbaee5a438de3b0f497c'}
 
     DATASET_SIZE = {'treclegal09_2k_subset' : 2.8,
-                    'treclegal09_20k_subset': 20,
-                    'treclegal09_37k_subset': 50}
+                    'treclegal09_20k_subset': 30,
+                    'treclegal09_37k_subset': 55}
 
     if name not in VALID_MD5SUM:
         raise ValueError('Dataset name {} not known!'.format(name))
@@ -82,7 +82,7 @@ def load_dataset(name='treclegal09_2k_subset', cache_dir='/tmp',
     if not os.path.exists(outdir):
 
         if verbose:
-            print('\nWaring: downloading dataset {} ({} MB) !'.format(name,
+            print('\nWarning: downloading dataset {} ({} MB) !'.format(name,
                                         DATASET_SIZE[name]))
         response = requests.get(base_url, stream=False, allow_redirects=True)
         with open(fname, "wb") as fh:

--- a/freediscovery/tests/test_categorize.py
+++ b/freediscovery/tests/test_categorize.py
@@ -19,7 +19,6 @@ from freediscovery.categorization import Categorizer
 from freediscovery.io import parse_ground_truth_file
 from freediscovery.utils import classification_score
 from freediscovery.exceptions import OptionalDependencyMissing
-from ..utils import _silent
 from .run_suite import check_cache
 
 

--- a/freediscovery/tests/test_datasets.py
+++ b/freediscovery/tests/test_datasets.py
@@ -1,0 +1,34 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
+import os.path
+import numpy as np
+from numpy.testing import assert_allclose, assert_equal
+import pytest
+
+from .run_suite import check_cache
+
+from freediscovery.datasets import load_dataset
+from unittest import SkipTest
+
+
+def test_load_dataset():
+    try:
+        from unittest.mock import patch, MagicMock
+    except ImportError:
+        raise SkipTest
+
+
+    cache_dir = check_cache()
+    m = MagicMock()
+    m2 = MagicMock()
+    with patch.dict("sys.modules", requests=m, tarfile=m2):
+        res = load_dataset(verbose=False, force=True, cache_dir=cache_dir,
+                       load_ground_truth=False, verify_checksum=False)
+    assert sorted(res.keys()) == sorted([#"ground_truth_file", "seed_non_relevant_files",
+                                         #"seed_relevant_files",
+                                         "base_dir", "data_dir"])
+


### PR DESCRIPTION
This PR adds a mechanism for loading benchmark datasets (issue #9). Previously example had to include a number of helper functions, and relative paths to account for the difference in the environment, with this PR all the required operations are done internally with a call,
    
        GET /api/v0/datasets/<dataset-name>

where `<dataset-name>` is one of,

         - treclegal09_2k_subset  :   2 400 documents,   2 MB
         - treclegal09_20k_subset :  20 000 documents,  30 MB
         - treclegal09_37k_subset :  37 000 documents,  55 MB
         - treclegal09            : 700 000 documents, 1.2 GB 

This allows to,
   - simplify the examples files by removing all helper  functions relative to path transformations and OS compatibillity https://freediscovery.github.io/doc/dev/examples/index.html
   - use the same examples file for the Docker and the development setup (previously a flag had to be changed)
   - run the examples from any location (previously it would fails if the files were not placed in `FreeDiscovery/examples`)
  - remove the need for the `curl` dependency
  - simplifies the scaling benchmarks (one can simply change the `<dataset-name>` in the example, that will download all the data / ground truth files).

The examples files are also [now tested on Windows](https://ci.appveyor.com/project/rth/freediscovery/build/1.0.59/job/r7haang4c7fjpr3x), however due to some issue in exit status propagation (in PowerShell), the tests will be marked as successful even if an example fail (and the output need to be reviewed manually for now).