### PR TITLE
FIX Numeric indexing of the documents in categorization and LSI

### DIFF
--- a/doc/python_api.rst
+++ b/doc/python_api.rst
@@ -65,7 +65,6 @@ Tools
 
     freediscovery.base.BaseEstimator
     freediscovery.io.parse_ground_truth_file
-    freediscovery.utils.filter_rel_nrel
     freediscovery.utils.generate_uuid
     freediscovery.utils.setup_model
 

--- a/doc/rest_api/categorization_post.md
+++ b/doc/rest_api/categorization_post.md
@@ -6,8 +6,8 @@ The option `use_hashing=True` must be set for the feature extraction. Recommende
  * **Method**: `POST` **URL Params**: None
  * **Data Params**: 
     - `dataset_id`: dataset id
-    - `relevant_filenames`: [required] list of relevant filenames
-    - `non_relevant_filenames`: [required] list of not relevant filenames
+    - `index`: [required] document indices of the training set
+    - `y`: [required] target binary class relative to index
     - `method`: classification algorithm to use (default: LogisticRegression),
           * "LogisticRegression": [LogisticRegression](http://scikit-learn.org/stable/modules/generated/sklearn.linear_model.LogisticRegression.html#sklearn.linear_model.LogisticRegression)
           * "LinearSVC": [Linear SVM](http://scikit-learn.org/stable/modules/generated/sklearn.svm.LinearSVC.html),

--- a/doc/rest_api/feature_extraction_index_get.md
+++ b/doc/rest_api/feature_extraction_index_get.md
@@ -1,0 +1,10 @@
+# Query document index for filenames
+
+ * **URL**: `/api/v0/feature-extraction/<dataset-id>/index`
+ * **Method**: `GET`,  **URL Params**: None
+ * **Data Params**: 
+    - `filenames`: [required] list of filenames
+
+ * **Success Response**: `HTTP 200`
+           
+         {"index": <list<int>> }

--- a/doc/rest_api/index.rst
+++ b/doc/rest_api/index.rst
@@ -15,13 +15,14 @@ Load Benchmark Dataset
 Feature Extraction 
 ------------------
 
-===================================================================================  ======  =========================================================
-`/api/v0/feature-extraction/ <./feature_extraction_post.html>`_                      POST    Load a dataset and initialize feature extraction
-`/api/v0/feature-extraction/ <./feature_extraction_get.html>`_                       GET     List processed datasets
-`/api/v0/feature-extraction/<dataset-id> <./feature_extraction_element_post.html>`_  POST    Run feature extraction on a dataset
-`/api/v0/feature-extraction/<dataset-id> <./feature_extraction_element_get.html>`_   GET     Load extracted features (and obtain the processing status)
-`/api/v0/feature-extraction/<dataset-id> <./feature_extraction_delete.html>`_        DELETE  Delete a processed dataset
-===================================================================================  ======  =========================================================
+=====================================================================================   ======  =========================================================
+`/api/v0/feature-extraction/ <./feature_extraction_post.html>`_                         POST    Load a dataset and initialize feature extraction
+`/api/v0/feature-extraction/ <./feature_extraction_get.html>`_                          GET     List processed datasets
+`/api/v0/feature-extraction/<dataset-id> <./feature_extraction_element_post.html>`_     POST    Run feature extraction on a dataset
+`/api/v0/feature-extraction/<dataset-id> <./feature_extraction_element_get.html>`_      GET     Load extracted features (and obtain the processing status)
+`/api/v0/feature-extraction/<dataset-id>/index <./feature_extraction_index_get.html>`_  GET     Query document index for filenames
+`/api/v0/feature-extraction/<dataset-id> <./feature_extraction_delete.html>`_           DELETE  Delete a processed dataset
+======================================================================================  ======  =========================================================
 
 Document Categorizaiton
 -----------------------

--- a/doc/rest_api/index.rst
+++ b/doc/rest_api/index.rst
@@ -15,14 +15,14 @@ Load Benchmark Dataset
 Feature Extraction 
 ------------------
 
-=====================================================================================   ======  =========================================================
+======================================================================================  ======  ==========================================================
 `/api/v0/feature-extraction/ <./feature_extraction_post.html>`_                         POST    Load a dataset and initialize feature extraction
 `/api/v0/feature-extraction/ <./feature_extraction_get.html>`_                          GET     List processed datasets
 `/api/v0/feature-extraction/<dataset-id> <./feature_extraction_element_post.html>`_     POST    Run feature extraction on a dataset
 `/api/v0/feature-extraction/<dataset-id> <./feature_extraction_element_get.html>`_      GET     Load extracted features (and obtain the processing status)
 `/api/v0/feature-extraction/<dataset-id>/index <./feature_extraction_index_get.html>`_  GET     Query document index for filenames
 `/api/v0/feature-extraction/<dataset-id> <./feature_extraction_delete.html>`_           DELETE  Delete a processed dataset
-======================================================================================  ======  =========================================================
+======================================================================================  ======  ==========================================================
 
 Document Categorizaiton
 -----------------------

--- a/doc/rest_api/lsi_predict_post.md
+++ b/doc/rest_api/lsi_predict_post.md
@@ -4,8 +4,8 @@
  * **URL**: `/api/v0/lsi/<lsi-id>/predict` 
  * **Method**: `POST` **URL Params**: None
  * **Data Params**: 
-    - `relevant_filenames`: [required] list of relevant filenames
-    - `non_relevant_filenames`: [required] list of not relevant filenames
+    - `index`: [required] document indices of the training set
+    - `y`: [required] target binary class relative to index
                     
 
  * **Success Response**: `HTTP 200`

--- a/examples/categorization_example.py
+++ b/examples/categorization_example.py
@@ -86,6 +86,11 @@ if __name__ == '__main__':
     print('\n'.join(['     - {}: {}'.format(key, val) for key, val in res.items() \
                                                       if "filenames" not in key]))
 
+    method = BASE_URL + "/feature-extraction/{}/index".format(dsid)
+    res = requests.get(method, data={'filenames': relevant_files})
+    relevant_id = res.json()['indices']
+    res = requests.get(method, data={'filenames': non_relevant_files})
+    non_relevant_id = res.json()['indices']
 
     # 2. Document categorization with ML algorithms
 
@@ -97,8 +102,8 @@ if __name__ == '__main__':
     print(' Training...')
 
     res = requests.post(url,
-                        json={'relevant_filenames': relevant_files,
-                              'non_relevant_filenames': non_relevant_files,
+                        json={'relevant_id': relevant_id,
+                              'non_relevant_id': non_relevant_id,
                               'dataset_id': dsid,
                               'method': 'LinearSVC',  # one of "LinearSVC", "LogisticRegression", 'xgboost'
                               'cv': 0                          # Cross Validation
@@ -157,8 +162,8 @@ if __name__ == '__main__':
     url = BASE_URL + '/lsi/{}/predict'.format(lid)
     print("POST", url)
     res = requests.post(url,
-                        json={'relevant_filenames': relevant_files,
-                              'non_relevant_filenames': non_relevant_files
+                        json={'relevant_id': relevant_id,
+                              'non_relevant_id': non_relevant_id
                               }).json()
     prediction = res['prediction']
 
@@ -171,10 +176,11 @@ if __name__ == '__main__':
     print(" POST", url)
 
     res = requests.post(url,
-                        json={'relevant_filenames': relevant_files,
-                              'non_relevant_filenames': non_relevant_files,
+                        json={'relevant_id': relevant_id,
+                              'non_relevant_id': non_relevant_id,
                               'ground_truth_filename': ground_truth_file
                               }).json()
+    print(res)
     print('    => Test scores: MAP = {average_precision:.3f}, ROC-AUC = {roc_auc:.3f}'.format(**res))
 
     print('\n', df)

--- a/examples/categorization_example.py
+++ b/examples/categorization_example.py
@@ -28,8 +28,8 @@ if __name__ == '__main__':
 
     # To use a custom dataset, simply specify the following variables
     data_dir = res['data_dir']
-    index_files = res['seed_relevant_files'] + res['seed_non_relevant_files']
-    y = [1]*len(res['seed_relevant_files']) + [0]*len(res['seed_non_relevant_files'])
+    seed_filenames = res['seed_filenames']
+    seed_y = res['seed_y']
     ground_truth_file = res['ground_truth_file']  # (optional)
 
 
@@ -87,20 +87,20 @@ if __name__ == '__main__':
                                                       if "filenames" not in key]))
 
     method = BASE_URL + "/feature-extraction/{}/index".format(dsid)
-    res = requests.get(method, data={'filenames': index_files})
-    index = res.json()['indices']
+    res = requests.get(method, data={'filenames': seed_filenames})
+    seed_index = res.json()['indices']
 
     # 2. Document categorization with ML algorithms
 
     print("\n2.a. Train the ML categorization model")
-    print("   {} relevant, {} non-relevant files".format(y.count(1), y.count(0)))
+    print("   {} relevant, {} non-relevant files".format(seed_y.count(1), seed_y.count(0)))
     url = BASE_URL + '/categorization/'
     print(" POST", url)
     print(' Training...')
 
     res = requests.post(url,
-                        json={'index': index,
-                              'y': y,
+                        json={'index': seed_index,
+                              'y': seed_y,
                               'dataset_id': dsid,
                               'method': 'LinearSVC',  # one of "LinearSVC", "LogisticRegression", 'xgboost'
                               'cv': 0                          # Cross Validation
@@ -159,8 +159,8 @@ if __name__ == '__main__':
     url = BASE_URL + '/lsi/{}/predict'.format(lid)
     print("POST", url)
     res = requests.post(url,
-                        json={'index': index,
-                              'y': y
+                        json={'index': seed_index,
+                              'y': seed_y
                               }).json()
     prediction = res['prediction']
 
@@ -173,8 +173,8 @@ if __name__ == '__main__':
     print(" POST", url)
 
     res = requests.post(url,
-                        json={'index': index,
-                              'y': y,
+                        json={'index': seed_index,
+                              'y': seed_y,
                               'ground_truth_filename': ground_truth_file
                               }).json()
     print(res)

--- a/examples/categorization_example.py
+++ b/examples/categorization_example.py
@@ -88,7 +88,7 @@ if __name__ == '__main__':
 
     method = BASE_URL + "/feature-extraction/{}/index".format(dsid)
     res = requests.get(method, data={'filenames': seed_filenames})
-    seed_index = res.json()['indices']
+    seed_index = res.json()['index']
 
     # 2. Document categorization with ML algorithms
 
@@ -116,7 +116,7 @@ if __name__ == '__main__':
     res = requests.get(url).json()
 
     print('\n'.join(['     - {}: {}'.format(key, val) for key, val in res.items() \
-                                                      if "filenames" not in key]))
+                                                      if key not in ['index', 'y']]))
 
     print("\n2.c Categorize the complete dataset with this model")
     url = BASE_URL + '/categorization/{}/predict'.format(mid)

--- a/examples/categorization_example.py
+++ b/examples/categorization_example.py
@@ -28,8 +28,8 @@ if __name__ == '__main__':
 
     # To use a custom dataset, simply specify the following variables
     data_dir = res['data_dir']
-    relevant_files = res['seed_relevant_files']
-    non_relevant_files = res['seed_non_relevant_files']
+    index_files = res['seed_relevant_files'] + res['seed_non_relevant_files']
+    y = [1]*len(res['seed_relevant_files']) + [0]*len(res['seed_non_relevant_files'])
     ground_truth_file = res['ground_truth_file']  # (optional)
 
 
@@ -87,23 +87,20 @@ if __name__ == '__main__':
                                                       if "filenames" not in key]))
 
     method = BASE_URL + "/feature-extraction/{}/index".format(dsid)
-    res = requests.get(method, data={'filenames': relevant_files})
-    relevant_id = res.json()['indices']
-    res = requests.get(method, data={'filenames': non_relevant_files})
-    non_relevant_id = res.json()['indices']
+    res = requests.get(method, data={'filenames': index_files})
+    index = res.json()['indices']
 
     # 2. Document categorization with ML algorithms
 
     print("\n2.a. Train the ML categorization model")
-    print("       {} relevant, {} non-relevant files".format(
-        len(relevant_files), len(non_relevant_files)))
+    print("   {} relevant, {} non-relevant files".format(y.count(1), y.count(0)))
     url = BASE_URL + '/categorization/'
     print(" POST", url)
     print(' Training...')
 
     res = requests.post(url,
-                        json={'relevant_id': relevant_id,
-                              'non_relevant_id': non_relevant_id,
+                        json={'index': index,
+                              'y': y,
                               'dataset_id': dsid,
                               'method': 'LinearSVC',  # one of "LinearSVC", "LogisticRegression", 'xgboost'
                               'cv': 0                          # Cross Validation
@@ -162,8 +159,8 @@ if __name__ == '__main__':
     url = BASE_URL + '/lsi/{}/predict'.format(lid)
     print("POST", url)
     res = requests.post(url,
-                        json={'relevant_id': relevant_id,
-                              'non_relevant_id': non_relevant_id
+                        json={'index': index,
+                              'y': y
                               }).json()
     prediction = res['prediction']
 
@@ -176,8 +173,8 @@ if __name__ == '__main__':
     print(" POST", url)
 
     res = requests.post(url,
-                        json={'relevant_id': relevant_id,
-                              'non_relevant_id': non_relevant_id,
+                        json={'index': index,
+                              'y': y,
                               'ground_truth_filename': ground_truth_file
                               }).json()
     print(res)

--- a/freediscovery/categorization.py
+++ b/freediscovery/categorization.py
@@ -163,7 +163,10 @@ class Categorizer(BaseEstimator):
            use cross-validation
         Returns
         -------
-           a dictionary with the results
+        cmod : sklearn.BaseEstimator
+           the scikit learn classifier object
+        Y_train : array-like, shape (n_samples)
+           training predictions
         """
 
         valid_methods = ["LinearSVC", "LogisticRegression", "xgboost"]
@@ -186,7 +189,6 @@ class Categorizer(BaseEstimator):
 
         X_train = d_all[index, :]
 
-        X_train_id = index
         Y_train = y
 
         if method != 'ensemble-stacking':
@@ -226,7 +228,7 @@ class Categorizer(BaseEstimator):
 
         self.mid = mid
         self.cmod = cmod
-        return cmod, X_train_id, Y_train
+        return cmod, Y_train
 
     def predict(self, chunk_size=5000):
         """

--- a/freediscovery/categorization.py
+++ b/freediscovery/categorization.py
@@ -13,7 +13,7 @@ from sklearn.externals import joblib
 
 from .text import FeatureVectorizer
 from .base import BaseEstimator
-from .utils import filter_rel_nrel, setup_model, _rename_main_thread
+from .utils import setup_model, _rename_main_thread
 from .exceptions import (ModelNotFound, WrongParameter, NotImplementedFD, OptionalDependencyMissing)
 
 
@@ -165,7 +165,12 @@ class Categorizer(BaseEstimator):
             if cv is not None:
                 raise WrongParameter('CV with ensemble stacking is not supported!')
 
-        d_all, _, _, d_rel, d_nrel = filter_rel_nrel(self, relevant_filenames, non_relevant_filenames)
+        idx_rel = self.fe.search(relevant_filenames, error_not_found=True)
+        idx_nrel = self.fe.search(non_relevant_filenames, error_not_found=True)
+
+        _, d_all = self.fe.load(self.dsid)  #, mmap_mode='r')
+        d_rel = d_all[idx_rel,:]
+        d_nrel = d_all[idx_nrel,:]
 
         X_train = scipy.sparse.vstack((d_rel, d_nrel))
         X_train_str = np.hstack((np.asarray(relevant_filenames), np.asarray(non_relevant_filenames)))

--- a/freediscovery/datasets.py
+++ b/freediscovery/datasets.py
@@ -12,6 +12,8 @@ import shutil
 import hashlib
 import platform
 
+import numpy as np
+
 
 def load_dataset(name='treclegal09_2k_subset', cache_dir='/tmp',
                  force=False, verbose=True,
@@ -138,8 +140,9 @@ def load_dataset(name='treclegal09_2k_subset', cache_dir='/tmp',
             relevant_files = [el.replace('/', '\\') for el in relevant_files]
             non_relevant_files = [el.replace('/', '\\') for el in non_relevant_files]
 
-        results['seed_non_relevant_files'] = non_relevant_files
-        results['seed_relevant_files'] = relevant_files
+        results['seed_filenames'] = relevant_files + non_relevant_files 
+        results['seed_y'] = list(np.concatenate((np.ones(len(relevant_files)),
+                                            np.zeros(len(non_relevant_files)))).astype('int'))
         results['ground_truth_file'] = ground_truth_file
 
     return results

--- a/freediscovery/lsi.py
+++ b/freediscovery/lsi.py
@@ -150,9 +150,6 @@ class LSI(BaseEstimator):
         d_p = ds[idx_p,:]
         d_n = ds[idx_n,:]
 
-        idx_train = np.concatenate((idx_p, idx_n), axis=0)
-        Y_train_ref = np.concatenate((np.ones((d_p.shape[0])), np.zeros((d_n.shape[0]))), axis=0)
-
         lsi = joblib.load(os.path.join(self.model_dir, self.mid, 'lsi_decomposition'))
 
         d_p_p = lsi.transform_lsi_norm(d_p)
@@ -187,7 +184,7 @@ class LSI(BaseEstimator):
         for key in res:
             res[key] = np.concatenate(res[key], axis=0)
 
-        idx_test = np.arange(self.fe.n_samples_, dtype='int')
+        
         D_rel = res['D_d_p']
         D_nrel = res['D_d_n']
         D_max = np.where(D_rel > D_nrel, D_rel, - D_nrel)
@@ -202,13 +199,12 @@ class LSI(BaseEstimator):
             D = res['D_centr_p']
         elif accumulate == 'stacking':
             from .private import lsi_stacking
-            D = lsi_stacking(res, Y_train_ref, idx_train)
+            D = lsi_stacking(res, y, index)
         else:
             raise NotImplementedFD('accumulate={} not supported!'.format(accumulate))
-        Y_train = D[idx_train]
+        Y_train = D[index]
         Y_test = D[:]
-        return (lsi, idx_train, Y_train_ref, Y_train,
-               idx_test, Y_test, res)
+        return (lsi, Y_train, Y_test, res)
 
     def list_models(self):
         lsi_path = os.path.join(self.fe.dsid_dir, 'lsi')

--- a/freediscovery/lsi.py
+++ b/freediscovery/lsi.py
@@ -141,8 +141,8 @@ class LSI(BaseEstimator):
         else:
             raise NotImplementedFD() 
 
+        index = np.asarray(index, dtype='int')
         y = np.asarray(y, dtype='int')
-        index = np.asarray(y, dtype='int')
 
         idx_p, idx_n = _unzip_relevant(index, y)
 
@@ -204,6 +204,18 @@ class LSI(BaseEstimator):
             raise NotImplementedFD('accumulate={} not supported!'.format(accumulate))
         Y_train = D[index]
         Y_test = D[:]
+
+        # transform nearest document from relative indexing
+        # (within the idx_p, idx_n) to absolute indexing
+        for key in res:
+            if key.startswith('idx'):
+                if key.endswith('_p'):
+                    idx_mapping = idx_p
+                elif key.endswith('_n'):
+                    idx_mapping = idx_n
+                else:
+                    raise ValueError
+                res[key] = idx_mapping[res[key]]
         return (lsi, Y_train, Y_test, res)
 
     def list_models(self):

--- a/freediscovery/lsi.py
+++ b/freediscovery/lsi.py
@@ -17,7 +17,7 @@ from sklearn.decomposition import TruncatedSVD
 
 from .text import FeatureVectorizer
 from .base import BaseEstimator
-from .utils import (filter_rel_nrel, setup_model)
+from .utils import setup_model
 from .exceptions import (WrongParameter, NotImplementedFD)
 
 
@@ -140,7 +140,12 @@ class LSI(BaseEstimator):
         else:
             raise NotImplementedFD() 
 
-        ds, idx_p, idx_n, d_p, d_n = filter_rel_nrel(self, relevant_filenames, non_relevant_filenames)
+        idx_p = self.fe.search(relevant_filenames, error_not_found=True)
+        idx_n = self.fe.search(non_relevant_filenames, error_not_found=True)
+
+        _, ds = self.fe.load(self.dsid)  #, mmap_mode='r')
+        d_p = ds[idx_p,:]
+        d_n = ds[idx_n,:]
 
         idx_train = np.concatenate((idx_p, idx_n), axis=0)
         X_train = np.hstack((np.asarray(relevant_filenames), np.asarray(non_relevant_filenames)))

--- a/freediscovery/lsi.py
+++ b/freediscovery/lsi.py
@@ -118,15 +118,15 @@ class LSI(BaseEstimator):
 
         return lsi, exp_var
 
-    def predict(self, relevant_filenames, non_relevant_filenames, accumulate='nearest-max', chunk_size=100):
+    def predict(self, relevant_id, non_relevant_id, accumulate='nearest-max', chunk_size=100):
         """
         Predict the document relevance using a previously trained LSI model
 
         Parameters
         ----------
-        relevant_filenames : list
+        relevant_id : list
            a list of relevant documents filenames
-        non_relevant_filenames : list
+        non_relevant_id : list
            a list of not relevant documents filenames
         accumulate : str, optional, default='nearest-max'
            if `accumulate=="nearest-max"` the cosine distance to the closest relevant/non relevant document is used as classification score,
@@ -140,15 +140,14 @@ class LSI(BaseEstimator):
         else:
             raise NotImplementedFD() 
 
-        idx_p = self.fe.search(relevant_filenames, error_not_found=True)
-        idx_n = self.fe.search(non_relevant_filenames, error_not_found=True)
+        idx_p = relevant_id
+        idx_n = non_relevant_id
 
         _, ds = self.fe.load(self.dsid)  #, mmap_mode='r')
         d_p = ds[idx_p,:]
         d_n = ds[idx_n,:]
 
         idx_train = np.concatenate((idx_p, idx_n), axis=0)
-        X_train = np.hstack((np.asarray(relevant_filenames), np.asarray(non_relevant_filenames)))
         Y_train_ref = np.concatenate((np.ones((d_p.shape[0])), np.zeros((d_n.shape[0]))), axis=0)
 
         lsi = joblib.load(os.path.join(self.model_dir, self.mid, 'lsi_decomposition'))
@@ -205,7 +204,7 @@ class LSI(BaseEstimator):
             raise NotImplementedFD('accumulate={} not supported!'.format(accumulate))
         Y_train = D[idx_train]
         Y_test = D[:]
-        return lsi, X_train, Y_train_ref, Y_train, X_test, Y_test, res
+        return lsi, None, Y_train_ref, Y_train, X_test, Y_test, res
 
     def list_models(self):
         lsi_path = os.path.join(self.fe.dsid_dir, 'lsi')

--- a/freediscovery/lsi.py
+++ b/freediscovery/lsi.py
@@ -17,6 +17,7 @@ from sklearn.decomposition import TruncatedSVD
 
 from .text import FeatureVectorizer
 from .base import BaseEstimator
+from .categorization import _zip_relevant
 from .utils import setup_model
 from .exceptions import (WrongParameter, NotImplementedFD)
 
@@ -204,7 +205,8 @@ class LSI(BaseEstimator):
             raise NotImplementedFD('accumulate={} not supported!'.format(accumulate))
         Y_train = D[idx_train]
         Y_test = D[:]
-        return lsi, None, Y_train_ref, Y_train, X_test, Y_test, res
+        return (lsi, idx_train, Y_train_ref, Y_train,
+               np.arange(len(self.fe._pars['filenames'])), Y_test, res)
 
     def list_models(self):
         lsi_path = os.path.join(self.fe.dsid_dir, 'lsi')

--- a/freediscovery/lsi.py
+++ b/freediscovery/lsi.py
@@ -185,7 +185,7 @@ class LSI(BaseEstimator):
         for key in res:
             res[key] = np.concatenate(res[key], axis=0)
 
-        X_test = np.asarray(self.fe._pars['filenames'])
+        idx_test = np.arange(self.fe.n_samples_, dtype='int')
         D_rel = res['D_d_p']
         D_nrel = res['D_d_n']
         D_max = np.where(D_rel > D_nrel, D_rel, - D_nrel)
@@ -206,7 +206,7 @@ class LSI(BaseEstimator):
         Y_train = D[idx_train]
         Y_test = D[:]
         return (lsi, idx_train, Y_train_ref, Y_train,
-               np.arange(len(self.fe._pars['filenames'])), Y_test, res)
+               idx_test, Y_test, res)
 
     def list_models(self):
         lsi_path = os.path.join(self.fe.dsid_dir, 'lsi')

--- a/freediscovery/lsi.py
+++ b/freediscovery/lsi.py
@@ -17,7 +17,7 @@ from sklearn.decomposition import TruncatedSVD
 
 from .text import FeatureVectorizer
 from .base import BaseEstimator
-from .categorization import _zip_relevant
+from .categorization import _unzip_relevant
 from .utils import setup_model
 from .exceptions import (WrongParameter, NotImplementedFD)
 
@@ -119,16 +119,16 @@ class LSI(BaseEstimator):
 
         return lsi, exp_var
 
-    def predict(self, relevant_id, non_relevant_id, accumulate='nearest-max', chunk_size=100):
+    def predict(self, index, y, accumulate='nearest-max', chunk_size=100):
         """
         Predict the document relevance using a previously trained LSI model
 
         Parameters
         ----------
-        relevant_id : list
-           a list of relevant documents filenames
-        non_relevant_id : list
-           a list of not relevant documents filenames
+        index : array-like, shape (n_samples)
+           document indices of the training set
+        y : array-like, shape (n_samples)
+           target binary class relative to index
         accumulate : str, optional, default='nearest-max'
            if `accumulate=="nearest-max"` the cosine distance to the closest relevant/non relevant document is used as classification score,
            otherwise if `accumulate=="centroid-max"` the centroid of relevant documents is used as the query vector.
@@ -141,8 +141,10 @@ class LSI(BaseEstimator):
         else:
             raise NotImplementedFD() 
 
-        idx_p = relevant_id
-        idx_n = non_relevant_id
+        y = np.asarray(y, dtype='int')
+        index = np.asarray(y, dtype='int')
+
+        idx_p, idx_n = _unzip_relevant(index, y)
 
         _, ds = self.fe.load(self.dsid)  #, mmap_mode='r')
         d_p = ds[idx_p,:]

--- a/freediscovery/server/app.py
+++ b/freediscovery/server/app.py
@@ -10,7 +10,8 @@ from flask import Flask
 from flask_restful import Api, Resource
 from flask import jsonify
 
-from .resources import (FeaturesApi, FeaturesApiElement, LsiApi, ModelsApi,
+from .resources import (FeaturesApi, FeaturesApiElement, FeaturesApiElementIndex,
+                        LsiApi, ModelsApi,
                         ModelsApiElement, ModelsApiPredict,
                         ModelsApiTest, LsiApiElement,
                         LsiApiElementTest, LsiApiElementPredict,
@@ -42,25 +43,27 @@ def fd_app(cache_dir):
 
 
     ## Actually setup the Api resource routing here
-    for resource_el, url in [(FeaturesApi,          "/feature-extraction"),
-                             (DatasetsApiElement,   "/datasets/<name>"),
-                             (FeaturesApiElement,   '/feature-extraction/<dsid>'),
-                             (ModelsApi,            '/categorization/'),
-                             (ModelsApiElement,     '/categorization/<mid>'),
-                             (ModelsApiPredict,     '/categorization/<mid>/predict'),
-                             (ModelsApiTest,        "/categorization/<mid>/test"),
-                             (LsiApi,               '/lsi/'),
-                             (LsiApiElement,        '/lsi/<mid>'),
-                             (LsiApiElementPredict, '/lsi/<mid>/predict'),
-                             (LsiApiElementTest,    '/lsi/<mid>/test'),
-                             (KmeanClusteringApi,   '/clustering/k-mean/'),
-                             (BirchClusteringApi,   '/clustering/birch'),
-                             (WardHCClusteringApi,  '/clustering/ward_hc'),
-                             (DBSCANClusteringApi,  '/clustering/dbscan'),
-                             (ClusteringApiElement, '/clustering/<method>/<mid>'),
-                             (DupDetectionApi,      '/duplicate-detection/'),
-                             (DupDetectionApiElement,'/duplicate-detection/<mid>'),
-                             #(CatchAll, "/<url>")
+    for resource_el, url in [
+         (DatasetsApiElement      , "/datasets/<name>")                      ,
+         (FeaturesApi             , "/feature-extraction")                   ,
+         (FeaturesApiElement      , '/feature-extraction/<dsid>')            ,
+         (FeaturesApiElementIndex , '/feature-extraction/<dsid>/get_indices'),
+         (ModelsApi               , '/categorization/')                      ,
+         (ModelsApiElement        , '/categorization/<mid>')                 ,
+         (ModelsApiPredict        , '/categorization/<mid>/predict')         ,
+         (ModelsApiTest           , "/categorization/<mid>/test")            ,
+         (LsiApi                  , '/lsi/')                                 ,
+         (LsiApiElement           , '/lsi/<mid>')                            ,
+         (LsiApiElementPredict    , '/lsi/<mid>/predict')                    ,
+         (LsiApiElementTest       , '/lsi/<mid>/test')                       ,
+         (KmeanClusteringApi      , '/clustering/k-mean/')                   ,
+         (BirchClusteringApi      , '/clustering/birch')                     ,
+         (WardHCClusteringApi     , '/clustering/ward_hc')                   ,
+         (DBSCANClusteringApi     , '/clustering/dbscan')                    ,
+         (ClusteringApiElement    , '/clustering/<method>/<mid>')            ,
+         (DupDetectionApi         , '/duplicate-detection/')                 ,
+         (DupDetectionApiElement  , '/duplicate-detection/<mid>')            ,
+         #(CatchAll               , "/<url>")
                              ]:
         # monkeypatching, not great
         resource_el._cache_dir = cache_dir

--- a/freediscovery/server/app.py
+++ b/freediscovery/server/app.py
@@ -47,7 +47,7 @@ def fd_app(cache_dir):
          (DatasetsApiElement      , "/datasets/<name>")                      ,
          (FeaturesApi             , "/feature-extraction")                   ,
          (FeaturesApiElement      , '/feature-extraction/<dsid>')            ,
-         (FeaturesApiElementIndex , '/feature-extraction/<dsid>/get_indices'),
+         (FeaturesApiElementIndex , '/feature-extraction/<dsid>/index'),
          (ModelsApi               , '/categorization/')                      ,
          (ModelsApiElement        , '/categorization/<mid>')                 ,
          (ModelsApiPredict        , '/categorization/<mid>/predict')         ,

--- a/freediscovery/server/resources.py
+++ b/freediscovery/server/resources.py
@@ -113,14 +113,8 @@ class FeaturesApiElementIndex(Resource):
     @marshal_with(FeaturesElementIndexSchema())
     def get(self, dsid, **args):
         fe = FeatureVectorizer(self._cache_dir, dsid=dsid)
-        #out = []
-        #for filenames_slice in args['filenames']:
-        #idx = fe.search(filenames_slice)
         idx = fe.search(args['filenames'])
         return {'indices': list(idx)}
-        #    if idx is not None:
-        #        out.append(idx)
-        #return idx
 
 # ============================================================================ # 
 #                  Categorization (LSI)
@@ -161,8 +155,8 @@ class LsiApiElement(Resource):
 _lsi_api_element_predict_post_args = {
         # Warning this should be changed to wfields.DelimitedList
         # https://webargs.readthedocs.io/en/latest/api.html#webargs.fields.DelimitedList
-        'relevant_id': wfields.List(wfields.Int(), required=True),
-        'non_relevant_id': wfields.List(wfields.Int(), required=True),
+        'index': wfields.List(wfields.Int(), required=True),
+        'y': wfields.List(wfields.Int(), required=True),
         }
 
 
@@ -186,8 +180,8 @@ class LsiApiElementPredict(Resource):
 _lsi_api_element_test_post_args = {
         # Warning this should be changed to wfields.DelimitedList
         # https://webargs.readthedocs.io/en/latest/api.html#webargs.fields.DelimitedList
-        'relevant_id': wfields.List(wfields.Int(), required=True),
-        'non_relevant_id': wfields.List(wfields.Int(), required=True),
+        'index': wfields.List(wfields.Int(), required=True),
+        'y': wfields.List(wfields.Int(), required=True),
         'ground_truth_filename': wfields.Str(required=True)
         }
 
@@ -217,8 +211,8 @@ _models_api_post_args = {
         'dataset_id': wfields.Str(required=True),
         # Warning this should be changed to wfields.DelimitedList
         # https://webargs.readthedocs.io/en/latest/api.html#webargs.fields.DelimitedList
-        'relevant_id': wfields.List(wfields.Int(), required=True),
-        'non_relevant_id': wfields.List(wfields.Int(), required=True),
+        'index': wfields.List(wfields.Int(), required=True),
+        'y': wfields.List(wfields.Int(), required=True),
         'method': wfields.Str(required=True),
         'cv': wfields.Boolean(missing=True),
         'training_scores': wfields.Boolean(missing=True)

--- a/freediscovery/server/resources.py
+++ b/freediscovery/server/resources.py
@@ -114,7 +114,7 @@ class FeaturesApiElementIndex(Resource):
     def get(self, dsid, **args):
         fe = FeatureVectorizer(self._cache_dir, dsid=dsid)
         idx = fe.search(args['filenames'])
-        return {'indices': list(idx)}
+        return {'index': list(idx)}
 
 # ============================================================================ # 
 #                  Categorization (LSI)

--- a/freediscovery/server/resources.py
+++ b/freediscovery/server/resources.py
@@ -18,7 +18,8 @@ from ..io import parse_ground_truth_file
 from ..utils import classification_score
 from ..cluster import Clustering
 from .schemas import (IDSchema, FeaturesParsSchema,
-                      FeaturesSchema, DatasetSchema,
+                      FeaturesSchema, FeaturesElementIndexSchema,
+                      DatasetSchema,
                       LsiParsSchema, LsiPostSchema, LsiPredictSchema,
                       ClassificationScoresSchema,
                       CategorizationParsSchema, CategorizationPostSchema,
@@ -105,6 +106,20 @@ class FeaturesApiElement(Resource):
         fe = FeatureVectorizer(self._cache_dir, dsid=dsid)
         fe.delete()
 
+_features_api_index_get_args = {'filenames': wfields.List(wfields.Str(), required=True)}
+class FeaturesApiElementIndex(Resource):
+    @use_args(_features_api_index_get_args)
+    @marshal_with(FeaturesElementIndexSchema())
+    def get(self, dsid, **args):
+        fe = FeatureVectorizer(self._cache_dir, dsid=dsid)
+        #out = []
+        #for filenames_slice in args['filenames']:
+        #idx = fe.search(filenames_slice)
+        idx = fe.search(args['filenames'])
+        return {'indices': list(idx)}
+        #    if idx is not None:
+        #        out.append(idx)
+        #return idx
 
 # ============================================================================ # 
 #                  Categorization (LSI)

--- a/freediscovery/server/resources.py
+++ b/freediscovery/server/resources.py
@@ -160,8 +160,8 @@ class LsiApiElement(Resource):
 _lsi_api_element_predict_post_args = {
         # Warning this should be changed to wfields.DelimitedList
         # https://webargs.readthedocs.io/en/latest/api.html#webargs.fields.DelimitedList
-        'relevant_filenames': wfields.List(wfields.Str(), required=True),
-        'non_relevant_filenames': wfields.List(wfields.Str(), required=True),
+        'relevant_id': wfields.List(wfields.Int(), required=True),
+        'non_relevant_id': wfields.List(wfields.Int(), required=True),
         }
 
 
@@ -212,8 +212,8 @@ _models_api_post_args = {
         'dataset_id': wfields.Str(required=True),
         # Warning this should be changed to wfields.DelimitedList
         # https://webargs.readthedocs.io/en/latest/api.html#webargs.fields.DelimitedList
-        'relevant_filenames': wfields.List(wfields.Str(), required=True),
-        'non_relevant_filenames': wfields.List(wfields.Str(), required=True),
+        'relevant_id': wfields.List(wfields.Int(), required=True),
+        'non_relevant_id': wfields.List(wfields.Int(), required=True),
         'method': wfields.Str(required=True),
         'cv': wfields.Boolean(missing=True),
         'training_scores': wfields.Boolean(missing=True)

--- a/freediscovery/server/schemas.py
+++ b/freediscovery/server/schemas.py
@@ -16,8 +16,8 @@ class DatasetSchema(Schema):
     base_dir = fields.Str(required=True)
     data_dir = fields.Str(required=True)
     ground_truth_file = fields.Str()
-    seed_relevant_files = fields.List(fields.Str())
-    seed_non_relevant_files = fields.List(fields.Str())
+    seed_filenames = fields.List(fields.Str())
+    seed_y = fields.List(fields.Int())
 
 class IDSchema(Schema):
     id = fields.Str(required=True)

--- a/freediscovery/server/schemas.py
+++ b/freediscovery/server/schemas.py
@@ -50,6 +50,8 @@ class FeaturesSchema(FeaturesParsSchema):
     id = fields.Str(required=True)
     filenames = fields.List(fields.Str())
 
+class FeaturesElementIndexSchema(Schema):
+    indices = fields.List(fields.Int(), required=True)
 
 class ClassificationScoresSchema(Schema):
     precision = fields.Number(required=True)

--- a/freediscovery/server/schemas.py
+++ b/freediscovery/server/schemas.py
@@ -88,8 +88,8 @@ class CategorizationPredictSchema(Schema):
 
 class CategorizationParsSchema(Schema):
     method = fields.Str(required=True)
-    relevant_filenames = fields.List(fields.Str(), required=True)
-    non_relevant_filenames = fields.List(fields.Str(), required=True)
+    relevant_id = fields.List(fields.Int(), required=True)
+    non_relevant_id = fields.List(fields.Int(), required=True)
     options = fields.Str(required=True)
 
 

--- a/freediscovery/server/schemas.py
+++ b/freediscovery/server/schemas.py
@@ -88,8 +88,8 @@ class CategorizationPredictSchema(Schema):
 
 class CategorizationParsSchema(Schema):
     method = fields.Str(required=True)
-    relevant_id = fields.List(fields.Int(), required=True)
-    non_relevant_id = fields.List(fields.Int(), required=True)
+    index = fields.List(fields.Int(), required=True)
+    y = fields.List(fields.Int(), required=True)
     options = fields.Str(required=True)
 
 

--- a/freediscovery/server/schemas.py
+++ b/freediscovery/server/schemas.py
@@ -51,7 +51,7 @@ class FeaturesSchema(FeaturesParsSchema):
     filenames = fields.List(fields.Str())
 
 class FeaturesElementIndexSchema(Schema):
-    indices = fields.List(fields.Int(), required=True)
+    index = fields.List(fields.Int(), required=True)
 
 class ClassificationScoresSchema(Schema):
     precision = fields.Number(required=True)

--- a/freediscovery/tests/run_suite.py
+++ b/freediscovery/tests/run_suite.py
@@ -8,7 +8,7 @@ base_dir = os.path.dirname(__file__)
 
 def run(coverage=False):
     import pytest
-    argv = ['-x', base_dir, '-v']  #, "
+    argv = ['-x', base_dir, '-v', '-s']  #, "
     if coverage:
         argv += ["--cov=freediscovery"]
     result = pytest.main(argv)

--- a/freediscovery/tests/test_categorize.py
+++ b/freediscovery/tests/test_categorize.py
@@ -71,9 +71,10 @@ def test_categorization(method, cv):
 
 
     Y_pred = cat.predict()
-    X_pred = cat.fe._pars['filenames']
+    X_pred = np.arange(cat.fe.n_samples_, dtype='int')
+    idx_gt = cat.fe.search(ground_truth.index.values)
 
-    scores = categorization_score(ground_truth.index.values,
+    scores = categorization_score(idx_gt,
                         ground_truth.is_relevant.values,
                         X_pred, Y_pred)
 
@@ -93,9 +94,12 @@ def test_unique_label():
     np.random.seed(10)
     Nshape = ground_truth.index.values.shape
     is_relevant = np.zeros(Nshape).astype(int)
-    scores = categorization_score(ground_truth.index.values,
+
+    idx = np.arange(len(is_relevant), dtype='int')
+
+    scores = categorization_score(idx,
                         is_relevant,
-                        ground_truth.index.values,
+                        idx,
                         np.random.rand(*Nshape))
     # TODO unused variable 'scores'
 

--- a/freediscovery/tests/test_categorize.py
+++ b/freediscovery/tests/test_categorize.py
@@ -57,13 +57,12 @@ def test_categorization(method, cv):
             raise SkipTest
 
     cat = Categorizer(cache_dir=cache_dir, dsid=uuid, cv_n_folds=2)
-    mask = ground_truth.is_relevant.values == 1
-    idx_rel = cat.fe.search(ground_truth.index.values[mask])
-    idx_nrel = cat.fe.search(ground_truth.index.values[~mask])
-    
+    index = cat.fe.search(ground_truth.index.values)
+
     try:
         coefs, X_train, Y_train = cat.train(
-                                idx_rel, idx_nrel,
+                                index,
+                                ground_truth.is_relevant.values,
                                 method=method,
                                 cv=cv)
     except OptionalDependencyMissing:

--- a/freediscovery/tests/test_categorize.py
+++ b/freediscovery/tests/test_categorize.py
@@ -69,6 +69,7 @@ def test_categorization(method, cv):
         raise SkipTest
 
 
+
     Y_pred = cat.predict()
     X_pred = np.arange(cat.fe.n_samples_, dtype='int')
     idx_gt = cat.fe.search(ground_truth.index.values)

--- a/freediscovery/tests/test_categorize.py
+++ b/freediscovery/tests/test_categorize.py
@@ -57,11 +57,12 @@ def test_categorization(method, cv):
 
     cat = Categorizer(cache_dir=cache_dir, dsid=uuid, cv_n_folds=2)
     mask = ground_truth.is_relevant.values == 1
+    idx_rel = cat.fe.search(ground_truth.index.values[mask])
+    idx_nrel = cat.fe.search(ground_truth.index.values[~mask])
     
     try:
         coefs, X_train, Y_train = cat.train(
-                                ground_truth.index.values[mask],
-                                ground_truth.index.values[~mask],
+                                idx_rel, idx_nrel,
                                 method=method,
                                 cv=cv)
     except OptionalDependencyMissing:

--- a/freediscovery/tests/test_categorize.py
+++ b/freediscovery/tests/test_categorize.py
@@ -15,7 +15,8 @@ import pytest
 import itertools
 
 from freediscovery.text import FeatureVectorizer
-from freediscovery.categorization import Categorizer
+from freediscovery.categorization import (Categorizer, _zip_relevant,
+        _unzip_relevant)
 from freediscovery.io import parse_ground_truth_file
 from freediscovery.utils import categorization_score
 from freediscovery.exceptions import OptionalDependencyMissing
@@ -116,6 +117,19 @@ def test_categorization_score():
     scores2 = categorization_score(idx_ref2, y_ref2, idx, y)
     assert scores['average_precision'] == scores2['average_precision']
 
+def test_relevant_zip():
+    relevant_id = [2, 3, 5]
+    non_relevant_id = [1, 7, 10]
+    idx_id = [2, 3, 5, 1, 7, 10]
+    y = [1, 1, 1, 0, 0, 0]
+
+    idx_id2, y2 = _zip_relevant(relevant_id, non_relevant_id)
+    assert_equal(idx_id, idx_id2)
+    assert_equal(y, y2)
+
+    relevant_id2, non_relevant_id2 = _unzip_relevant(idx_id2, y2)
+    assert_equal(relevant_id2, relevant_id)
+    assert_equal(non_relevant_id2, non_relevant_id)
 
 
 def test_ensemble_stacking():

--- a/freediscovery/tests/test_categorize.py
+++ b/freediscovery/tests/test_categorize.py
@@ -60,7 +60,7 @@ def test_categorization(method, cv):
     index = cat.fe.search(ground_truth.index.values)
 
     try:
-        coefs, X_train, Y_train = cat.train(
+        coefs, Y_train = cat.train(
                                 index,
                                 ground_truth.is_relevant.values,
                                 method=method,

--- a/freediscovery/tests/test_categorize.py
+++ b/freediscovery/tests/test_categorize.py
@@ -17,7 +17,7 @@ import itertools
 from freediscovery.text import FeatureVectorizer
 from freediscovery.categorization import Categorizer
 from freediscovery.io import parse_ground_truth_file
-from freediscovery.utils import classification_score
+from freediscovery.utils import categorization_score
 from freediscovery.exceptions import OptionalDependencyMissing
 from .run_suite import check_cache
 
@@ -72,7 +72,7 @@ def test_categorization(method, cv):
     Y_pred = cat.predict()
     X_pred = cat.fe._pars['filenames']
 
-    scores = classification_score(ground_truth.index.values,
+    scores = categorization_score(ground_truth.index.values,
                         ground_truth.is_relevant.values,
                         X_pred, Y_pred)
 
@@ -92,11 +92,30 @@ def test_unique_label():
     np.random.seed(10)
     Nshape = ground_truth.index.values.shape
     is_relevant = np.zeros(Nshape).astype(int)
-    scores = classification_score(ground_truth.index.values,
+    scores = categorization_score(ground_truth.index.values,
                         is_relevant,
                         ground_truth.index.values,
                         np.random.rand(*Nshape))
     # TODO unused variable 'scores'
+
+
+def test_categorization_score():
+    idx = [1, 2,  3,  4,  5, 6]
+    y   = [1, 1, -1, -1, -1, 1]
+    idx_ref = [10, 5, 3, 2, 6]
+    y_ref   = [0,  1, 0, 1, 1]
+
+    scores = categorization_score(idx_ref, y_ref, idx, y)
+
+    assert_allclose(scores['precision'], 1.0)
+    assert_allclose(scores['recall'], 0.66666666, rtol=1e-4)
+
+    # make sure permutations don't affect the result
+    idx_ref2 = [10, 5, 2, 3, 6]
+    y_ref2   = [0,  1, 1, 0, 1]
+    scores2 = categorization_score(idx_ref2, y_ref2, idx, y)
+    assert scores['average_precision'] == scores2['average_precision']
+
 
 
 def test_ensemble_stacking():

--- a/freediscovery/tests/test_lsi.py
+++ b/freediscovery/tests/test_lsi.py
@@ -44,7 +44,7 @@ def test_lsi():
 
     for accumulate in ['nearest-max', 'centroid-max']:
                         #'nearest-diff', 'nearest-combine', 'stacking']:
-        _, X_train, Y_train_val, Y_train, X_pred, Y_pred, ND_train = lsi.predict(
+        _, Y_train, Y_pred, ND_train = lsi.predict(
                                 index,
                                 ground_truth.is_relevant.values,
                                 accumulate=accumulate)

--- a/freediscovery/tests/test_lsi.py
+++ b/freediscovery/tests/test_lsi.py
@@ -39,11 +39,14 @@ def test_lsi():
 
     mask = ground_truth.is_relevant.values == 1
 
+    idx_rel = lsi.fe.search(ground_truth.index.values[mask])
+    idx_nrel = lsi.fe.search(ground_truth.index.values[~mask])
+
     for accumulate in ['nearest-max', 'centroid-max']:
                         #'nearest-diff', 'nearest-combine', 'stacking']:
         _, X_train, Y_train_val, Y_train, X_pred, Y_pred, ND_train = lsi.predict(
-                                ground_truth.index.values[mask],
-                                ground_truth.index.values[~mask],
+                                idx_rel,
+                                idx_nrel,
                                 accumulate=accumulate)
         scores = classification_score(ground_truth.index.values,
                             ground_truth.is_relevant.values,

--- a/freediscovery/tests/test_lsi.py
+++ b/freediscovery/tests/test_lsi.py
@@ -37,10 +37,7 @@ def test_lsi():
     assert lsi._load_pars(lsi_id) is not None
     lsi.load(lsi_id)
 
-    mask = ground_truth.is_relevant.values == 1
-
-    idx_rel = lsi.fe.search(ground_truth.index.values[mask])
-    idx_nrel = lsi.fe.search(ground_truth.index.values[~mask])
+    index = lsi.fe.search(ground_truth.index.values)
 
     idx_gt = lsi.fe.search(ground_truth.index.values)
     idx_all = np.arange(lsi.fe.n_samples_, dtype='int')
@@ -48,12 +45,16 @@ def test_lsi():
     for accumulate in ['nearest-max', 'centroid-max']:
                         #'nearest-diff', 'nearest-combine', 'stacking']:
         _, X_train, Y_train_val, Y_train, X_pred, Y_pred, ND_train = lsi.predict(
-                                idx_rel,
-                                idx_nrel,
+                                index,
+                                ground_truth.is_relevant.values,
                                 accumulate=accumulate)
+        print('accumulate: ', accumulate)
+        print(idx_gt, ground_truth.is_relevant.values)
+        print(idx_all, Y_pred)
         scores = categorization_score(idx_gt,
                             ground_truth.is_relevant.values,
                             idx_all, Y_pred)
+        print(scores)
         assert_allclose(scores['precision'], 1, rtol=0.5)
         assert_allclose(scores['recall'], 1, rtol=0.3)
 

--- a/freediscovery/tests/test_lsi.py
+++ b/freediscovery/tests/test_lsi.py
@@ -42,18 +42,22 @@ def test_lsi():
     idx_rel = lsi.fe.search(ground_truth.index.values[mask])
     idx_nrel = lsi.fe.search(ground_truth.index.values[~mask])
 
+    idx_gt = lsi.fe.search(ground_truth.index.values)
+    idx_all = np.arange(lsi.fe.n_samples_, dtype='int')
+
     for accumulate in ['nearest-max', 'centroid-max']:
                         #'nearest-diff', 'nearest-combine', 'stacking']:
         _, X_train, Y_train_val, Y_train, X_pred, Y_pred, ND_train = lsi.predict(
                                 idx_rel,
                                 idx_nrel,
                                 accumulate=accumulate)
-        scores = categorization_score(ground_truth.index.values,
+        scores = categorization_score(idx_gt,
                             ground_truth.is_relevant.values,
-                            X_pred, Y_pred)  # TODO unused variable
-        #yield assert_allclose, scores['precision_score'], 1
-        #yield assert_allclose, scores['recall_score'], 1
-        
+                            idx_all, Y_pred)
+        assert_allclose(scores['precision'], 1, rtol=0.5)
+        assert_allclose(scores['recall'], 1, rtol=0.3)
+
+
     lsi.list_models()
     lsi.delete()
 

--- a/freediscovery/tests/test_lsi.py
+++ b/freediscovery/tests/test_lsi.py
@@ -10,7 +10,7 @@ from numpy.testing import assert_allclose
 
 from freediscovery.text import FeatureVectorizer
 from freediscovery.lsi import LSI, TruncatedSVD_LSI
-from freediscovery.utils import classification_score
+from freediscovery.utils import categorization_score
 from freediscovery.io import parse_ground_truth_file
 from .run_suite import check_cache
 
@@ -48,7 +48,7 @@ def test_lsi():
                                 idx_rel,
                                 idx_nrel,
                                 accumulate=accumulate)
-        scores = classification_score(ground_truth.index.values,
+        scores = categorization_score(ground_truth.index.values,
                             ground_truth.is_relevant.values,
                             X_pred, Y_pred)  # TODO unused variable
         #yield assert_allclose, scores['precision_score'], 1

--- a/freediscovery/tests/test_lsi.py
+++ b/freediscovery/tests/test_lsi.py
@@ -37,24 +37,18 @@ def test_lsi():
     assert lsi._load_pars(lsi_id) is not None
     lsi.load(lsi_id)
 
-    index = lsi.fe.search(ground_truth.index.values)
-
     idx_gt = lsi.fe.search(ground_truth.index.values)
     idx_all = np.arange(lsi.fe.n_samples_, dtype='int')
 
     for accumulate in ['nearest-max', 'centroid-max']:
                         #'nearest-diff', 'nearest-combine', 'stacking']:
         _, Y_train, Y_pred, ND_train = lsi.predict(
-                                index,
+                                idx_gt,
                                 ground_truth.is_relevant.values,
                                 accumulate=accumulate)
-        print('accumulate: ', accumulate)
-        print(idx_gt, ground_truth.is_relevant.values)
-        print(idx_all, Y_pred)
         scores = categorization_score(idx_gt,
                             ground_truth.is_relevant.values,
                             idx_all, Y_pred)
-        print(scores)
         assert_allclose(scores['precision'], 1, rtol=0.5)
         assert_allclose(scores['recall'], 1, rtol=0.3)
 

--- a/freediscovery/tests/test_server.py
+++ b/freediscovery/tests/test_server.py
@@ -123,7 +123,7 @@ def test_api_lsi(app):
     method = V01 + "/feature-extraction/{}/index".format(dsid)
     res = app.get(method, data={'filenames': index_filenames})
     assert res.status_code == 200, method
-    index = parse_res(res)['indices']
+    index = parse_res(res)['index']
 
     lsi_pars = dict( n_components=101, dataset_id=dsid)
     method = V01 + "/lsi/"
@@ -203,7 +203,7 @@ def test_api_categorization(app, solver, cv):
     method = V01 + "/feature-extraction/{}/index".format(dsid)
     res = app.get(method, data={'filenames': index_filenames})
     assert res.status_code == 200, method
-    index = parse_res(res)['indices']
+    index = parse_res(res)['index']
 
 
     pars = {
@@ -383,8 +383,8 @@ def test_get_search_filenames(app):
         res = app.get(method, data=pars)
         assert res.status_code == 200
         data = parse_res(res)
-        assert sorted(data.keys()) ==  sorted(['indices'])
-        assert_equal(data['indices'], indices)
+        assert sorted(data.keys()) ==  sorted(['index'])
+        assert_equal(data['index'], indices)
 
 
 @pytest.mark.parametrize("method", ['feature-extraction', 'categorization', 'lsi', 'clustering'])

--- a/freediscovery/tests/test_server.py
+++ b/freediscovery/tests/test_server.py
@@ -170,8 +170,8 @@ def test_api_lsi(app):
     method = V01 + "/lsi/{}/test".format(lid)
     res = app.post(method,
             data={
-              'relevant_filenames': relevant_files,
-              'non_relevant_filenames': non_relevant_files,
+              'relevant_id': relevant_id,
+              'non_relevant_id': non_relevant_id,
               'ground_truth_filename': os.path.join(data_dir, '..', 'ground_truth_file.txt')
               })
 
@@ -234,10 +234,10 @@ def test_api_categorization(app, solver, cv):
     assert res.status_code == 200
     data = parse_res(res)
     assert sorted(data.keys()) == \
-            sorted(["relevant_filenames", "non_relevant_filenames",
+            sorted(["relevant_id", "non_relevant_id",
                     "method", "options"])
 
-    for key in ["relevant_filenames", "non_relevant_filenames", "method"]:
+    for key in ["relevant_id", "non_relevant_id", "method"]:
         if 'filenames' in key:
             assert len(pars[key]) == len(data[key])
         else:

--- a/freediscovery/tests/test_server.py
+++ b/freediscovery/tests/test_server.py
@@ -117,7 +117,7 @@ def test_api_lsi(app):
 
     filenames = data['filenames']
     # we train the model on 5 samples / 6 and see what happens
-    index_filenames = filenames[:1] + filenames[3:]
+    index_filenames = filenames[:2] + filenames[3:]
     y = [1, 1,  0, 0, 0]
 
     method = V01 + "/feature-extraction/{}/index".format(dsid)
@@ -330,8 +330,7 @@ def test_api_dupdetection(app, kind, options):
     res = app.get(url, data=options)
     assert res.status_code == 200
     data = parse_res(res)
-    assert sorted(data.keys()) == \
-            sorted(['cluster_id'])
+    assert sorted(data.keys()) == sorted(['cluster_id'])
 
     res = app.delete(method)
     assert res.status_code == 200
@@ -375,16 +374,29 @@ def test_get_feature_extraction(app):
 
 def test_get_search_filenames(app):
     dsid, _ = features_hashed(app)
+
+
+    method = V01 + "/feature-extraction/{}".format(dsid)
+    res = app.get(method)
+    assert res.status_code == 200
+    data = parse_res(res)
+
+    filenames = data['filenames']
+
+
+
     method = V01 + "/feature-extraction/{}/index".format(dsid)
     for pars, indices in [
-            ( { 'filenames': ['0.7.47.101442.txt', '0.7.47.117435.txt']}, [0, 1]),
+            ({ 'filenames': ['0.7.47.101442.txt', '0.7.47.117435.txt']}, [0, 1]),
             ({ 'filenames': ['0.7.6.28638.txt']}, [5])]:
 
         res = app.get(method, data=pars)
         assert res.status_code == 200
         data = parse_res(res)
         assert sorted(data.keys()) ==  sorted(['indices'])
-        assert_equal(sorted(data['indices']), indices)
+        print('filenames:', filenames)
+        print("data['indices']:", data['indices'])
+        assert_equal(data['indices'], indices)
 
 
 @pytest.mark.parametrize("method", ['feature-extraction', 'categorization', 'lsi', 'clustering'])
@@ -397,8 +409,7 @@ def test_get_model_404(app_notest, method):
     assert res.status_code in [500, 404] # depends on the url
     #assert '500' in data['message']
 
-    assert sorted(data.keys()) == \
-                    sorted(['message'])
+    assert sorted(data.keys()) == sorted(['message'])
 
 
 @pytest.mark.parametrize("method", ['feature-extraction', 'categorization', 'lsi', 'clustering'])

--- a/freediscovery/tests/test_server.py
+++ b/freediscovery/tests/test_server.py
@@ -169,8 +169,8 @@ def test_api_lsi(app):
     method = V01 + "/lsi/{}/test".format(lid)
     res = app.post(method,
             data={
-              'relevant_id': relevant_id,
-              'non_relevant_id': non_relevant_id,
+              'index': index,
+              'y': y,
               'ground_truth_filename': os.path.join(data_dir, '..', 'ground_truth_file.txt')
               })
 
@@ -434,8 +434,8 @@ def test_exception_handling(app_notest):
         res = app_notest.post(method,
                         data={
                               'dataset_id': dsid,
-                              'non_relevant_id': [0, 0, 0],       # just something wrong
-                              'relevant_id': ['ds', 'dsd', 'dsd'],
+                              'index': [0, 0, 0],       # just something wrong
+                              'y': ['ds', 'dsd', 'dsd'],
                               'method': "LogisticRegression",
                               'cv': 0,
                               })

--- a/freediscovery/tests/test_server.py
+++ b/freediscovery/tests/test_server.py
@@ -145,7 +145,7 @@ def test_api_lsi(app):
     for key, vals in lsi_pars.items():
         assert vals == data[key]
 
-    method = V01 + "/feature-extraction/{}/get_indices".format(dsid)
+    method = V01 + "/feature-extraction/{}/index".format(dsid)
     res = app.get(method, data={'filenames': relevant_files})
     assert res.status_code == 200, method
     relevant_id = parse_res(res)['indices']
@@ -201,7 +201,7 @@ def test_api_categorization(app, solver, cv):
     relevant_files = filenames[:3]
     non_relevant_files = filenames[3:]
 
-    method = V01 + "/feature-extraction/{}/get_indices".format(dsid)
+    method = V01 + "/feature-extraction/{}/index".format(dsid)
     res = app.get(method, data={'filenames': relevant_files})
     assert res.status_code == 200, method
     relevant_id = parse_res(res)['indices']
@@ -379,7 +379,7 @@ def test_get_feature_extraction(app):
 
 def test_get_search_filenames(app):
     dsid, _ = features_hashed(app)
-    method = V01 + "/feature-extraction/{}/get_indices".format(dsid)
+    method = V01 + "/feature-extraction/{}/index".format(dsid)
     for pars, indices in [
             ( { 'filenames': ['0.7.47.101442.txt', '0.7.47.117435.txt']}, [0, 1]),
             ({ 'filenames': ['0.7.6.28638.txt']}, [5])]:

--- a/freediscovery/tests/test_server.py
+++ b/freediscovery/tests/test_server.py
@@ -375,16 +375,6 @@ def test_get_feature_extraction(app):
 def test_get_search_filenames(app):
     dsid, _ = features_hashed(app)
 
-
-    method = V01 + "/feature-extraction/{}".format(dsid)
-    res = app.get(method)
-    assert res.status_code == 200
-    data = parse_res(res)
-
-    filenames = data['filenames']
-
-
-
     method = V01 + "/feature-extraction/{}/index".format(dsid)
     for pars, indices in [
             ({ 'filenames': ['0.7.47.101442.txt', '0.7.47.117435.txt']}, [0, 1]),
@@ -394,8 +384,6 @@ def test_get_search_filenames(app):
         assert res.status_code == 200
         data = parse_res(res)
         assert sorted(data.keys()) ==  sorted(['indices'])
-        print('filenames:', filenames)
-        print("data['indices']:", data['indices'])
         assert_equal(data['indices'], indices)
 
 

--- a/freediscovery/tests/test_text.py
+++ b/freediscovery/tests/test_text.py
@@ -73,7 +73,7 @@ def test_search_filenames(use_hashing):
         idx_slice = list(range(low, high))
         filenames_slice = [filenames[idx] for idx in idx_slice]
         idx0 = fe.search(filenames_slice)
-        assert_equal(sorted(idx0), sorted(idx_slice))
+        assert_equal(idx0, idx_slice)
 
     idx1 = fe.search(['DOES_NOT_EXIST.txt'])
     assert idx1 is None

--- a/freediscovery/tests/test_text.py
+++ b/freediscovery/tests/test_text.py
@@ -75,8 +75,8 @@ def test_search_filenames(use_hashing):
         idx0 = fe.search(filenames_slice)
         assert_equal(idx0, idx_slice)
 
-    idx1 = fe.search(['DOES_NOT_EXIST.txt'])
-    assert idx1 is None
+    with pytest.raises(ValueError):
+        fe.search(['DOES_NOT_EXIST.txt'])
 
     if not use_hashing:
         n_top_words = 5

--- a/freediscovery/tests/test_text.py
+++ b/freediscovery/tests/test_text.py
@@ -67,15 +67,16 @@ def test_search_filenames(use_hashing):
 
 
 
-    for low, high in [(0, 1),
-                      (0, 4),
-                      (1, 3)]:
-        idx_slice = list(range(low, high))
+    for low, high, step in [(0, 1, 1),
+                            (0, 4, 1),
+                            (3, 1, -1)]:
+        idx_slice = list(range(low, high, step))
         filenames_slice = [filenames[idx] for idx in idx_slice]
         idx0 = fe.search(filenames_slice)
         assert_equal(idx0, idx_slice)
+        assert_equal(filenames_slice, fe[idx0])
 
-    with pytest.raises(ValueError):
+    with pytest.raises(KeyError):
         fe.search(['DOES_NOT_EXIST.txt'])
 
     if not use_hashing:

--- a/freediscovery/text.py
+++ b/freediscovery/text.py
@@ -106,6 +106,9 @@ class FeatureVectorizer(object):
                     if re.match(file_pattern, fname):
                         filenames.append(os.path.normpath(os.path.join(root, fname)))
 
+        # make sure that sorting order is deterministic
+        filenames = sorted(filenames)
+
         if not filenames: # no files were found
             raise WrongParameter('No files to process were found!')
         if analyzer not in ['word', 'char', 'char_wb']:

--- a/freediscovery/text.py
+++ b/freediscovery/text.py
@@ -317,8 +317,8 @@ class FeatureVectorizer(object):
         pars = joblib.load(os.path.join(dsid_dir, 'pars'))
         return pars
 
-    def search(self, filenames):
-        """ Given a dsid return the features that correspond to the provided filenames """
+    def search(self, filenames, error_not_found=False):
+        """ Return the document ids that correspond to the provided filenames """
         pars = self._pars
         filenames_all = pars['filenames']
         # calculate the indices of the intersection of filenames with filenames_all
@@ -328,7 +328,10 @@ class FeatureVectorizer(object):
         if len(filenames) == len(indices):
             return indices
         elif len(indices) == 0:
-            return None  # np.zeros(len(filenames)).astype(bool)
+            if error_not_found:
+                raise ValueError('No relevant files found with the input provided: {} ...!'.format(filenames[:20]))
+            else:
+                return None  # np.zeros(len(filenames)).astype(bool)
         elif len(filenames) != len(indices):
             # this is not supposed to happen, we should do something
             raise ValueError("unconsistant indices, the results may be wrong!")

--- a/freediscovery/text.py
+++ b/freediscovery/text.py
@@ -326,26 +326,22 @@ class FeatureVectorizer(object):
         filenames : list[str]
             list of filenames (relatives to the data_dir)
         error_not_found : bool
-            raise an error if no 
+            raise an error if no files found
 
         Returns
         -------
         indices : array[int]
             corresponding list of document id (order is not preserved)
         """
-        pars = self._pars
-        filenames_all = pars['filenames']
+        filenames = np.array(filenames)
+        filenames_all = np.array(self._pars['filenames'])
         # calculate the indices of the intersection of filenames with filenames_all
-        ind_dict = dict((k,i) for i,k in enumerate(filenames_all))
-        inter =  set(ind_dict).intersection(filenames)
-        indices = np.asarray([ ind_dict[x] for x in inter])
-        if len(filenames) == len(indices):
-            return indices
-        elif len(indices) == 0:
+        mask = np.in1d(filenames_all, filenames)
+        indices = np.nonzero(mask)[0]
+        if len(indices) == 0:
             if error_not_found:
                 raise ValueError('No relevant files found with the input provided: {} ...!'.format(filenames[:20]))
             else:
                 return None  # np.zeros(len(filenames)).astype(bool)
-        elif len(filenames) != len(indices):
-            # this is not supposed to happen, we should do something
-            raise ValueError("unconsistant indices, the results may be wrong!")
+        else:
+            return indices

--- a/freediscovery/text.py
+++ b/freediscovery/text.py
@@ -27,7 +27,7 @@ def _vectorize_chunk(dsid_dir, k, pars, pretend=False):
     from sklearn.feature_extraction.text import HashingVectorizer
     from sklearn.externals import joblib
 
-    filenames = pars['filenames']
+    filenames = pars['filenames_abs']
     chunk_size = pars['chunk_size']
     n_samples = pars['n_samples']
 
@@ -169,7 +169,7 @@ class FeatureVectorizer(object):
         pars = self._pars
         filenames_base = pars['filenames']
         data_dir = pars['data_dir']
-        pars['filenames'] = [os.path.join(data_dir, el) for el in filenames_base]
+        pars['filenames_abs'] = [os.path.join(data_dir, el) for el in filenames_base]
         chunk_size = pars['chunk_size']
         n_samples = pars['n_samples']
         n_jobs = pars['n_jobs']
@@ -206,7 +206,7 @@ class FeatureVectorizer(object):
                             max_features=pars['n_features'],
                             norm=pars['norm'],
                             decode_error='ignore', **opts_tfidf)
-                res = tfidf.fit_transform(pars['filenames'])
+                res = tfidf.fit_transform(pars['filenames_abs'])
                 joblib.dump(tfidf, os.path.join(dsid_dir, 'vectorizer'))
                 self.vect = tfidf
 
@@ -318,7 +318,21 @@ class FeatureVectorizer(object):
         return pars
 
     def search(self, filenames, error_not_found=False):
-        """ Return the document ids that correspond to the provided filenames """
+        """ Return the document ids that correspond to the provided filenames,
+        without preserving order.
+
+        Parameters
+        ----------
+        filenames : list[str]
+            list of filenames (relatives to the data_dir)
+        error_not_found : bool
+            raise an error if no 
+
+        Returns
+        -------
+        indices : array[int]
+            corresponding list of document id (order is not preserved)
+        """
         pars = self._pars
         filenames_all = pars['filenames']
         # calculate the indices of the intersection of filenames with filenames_all

--- a/freediscovery/text.py
+++ b/freediscovery/text.py
@@ -265,6 +265,9 @@ class FeatureVectorizer(object):
         dsid_dir = os.path.join(self.cache_dir, dsid)
         return os.path.exists(dsid_dir)
 
+    def __getitem__(self, index):
+        return np.asarray(self._pars['filenames'])[index]
+
     def list_datasets(self):
         """ List all datasets in the working directory """
         out = []
@@ -320,7 +323,7 @@ class FeatureVectorizer(object):
         pars = joblib.load(os.path.join(dsid_dir, 'pars'))
         return pars
 
-    def search(self, filenames, error_not_found=True):
+    def search(self, filenames):
         """ Return the document ids that correspond to the provided filenames,
         without preserving order.
 
@@ -328,24 +331,17 @@ class FeatureVectorizer(object):
         ----------
         filenames : list[str]
             list of filenames (relatives to the data_dir)
-        error_not_found : bool
-            raise an error if a file is not found (otherwise fail silently)
 
         Returns
         -------
         indices : array[int]
             corresponding list of document id (order is not preserved)
         """
-        filenames = np.array(filenames)
-        filenames_all = np.array(self._pars['filenames'])
-        if error_not_found:
-            mask_inv = np.in1d(filenames, filenames_all)
-            if (~mask_inv).any():
-                raise ValueError('Files not found :  {} ...!'.format(filenames[~mask_inv][:20]))
+        filenames_all = self._pars['filenames']
         # calculate the indices of the intersection of filenames with filenames_all
-        mask = np.in1d(filenames_all, filenames)
-        indices = np.nonzero(mask)[0]
-        return indices
+        ind_dict = dict((k,i) for i,k in enumerate(filenames_all))
+        indices = [ ind_dict[x] for x in filenames]
+        return np.array(indices)
 
     @property
     def n_samples_(self):

--- a/freediscovery/text.py
+++ b/freediscovery/text.py
@@ -317,7 +317,7 @@ class FeatureVectorizer(object):
         pars = joblib.load(os.path.join(dsid_dir, 'pars'))
         return pars
 
-    def search(self, filenames, error_not_found=False):
+    def search(self, filenames, error_not_found=True):
         """ Return the document ids that correspond to the provided filenames,
         without preserving order.
 
@@ -326,7 +326,7 @@ class FeatureVectorizer(object):
         filenames : list[str]
             list of filenames (relatives to the data_dir)
         error_not_found : bool
-            raise an error if no files found
+            raise an error if a file is not found (otherwise fail silently)
 
         Returns
         -------
@@ -335,13 +335,16 @@ class FeatureVectorizer(object):
         """
         filenames = np.array(filenames)
         filenames_all = np.array(self._pars['filenames'])
+        if error_not_found:
+            mask_inv = np.in1d(filenames, filenames_all)
+            if (~mask_inv).any():
+                raise ValueError('Files not found :  {} ...!'.format(filenames[~mask_inv][:20]))
         # calculate the indices of the intersection of filenames with filenames_all
         mask = np.in1d(filenames_all, filenames)
         indices = np.nonzero(mask)[0]
-        if len(indices) == 0:
-            if error_not_found:
-                raise ValueError('No relevant files found with the input provided: {} ...!'.format(filenames[:20]))
-            else:
-                return None  # np.zeros(len(filenames)).astype(bool)
-        else:
-            return indices
+        return indices
+
+    @property
+    def n_samples_(self):
+        """ Number of documents in the dataset """
+        return len(self._pars['filenames'])

--- a/freediscovery/utils.py
+++ b/freediscovery/utils.py
@@ -71,7 +71,7 @@ def categorization_score(idx_ref, Y_ref, idx, Y):
         m_recall_score = recall_score(Y_ref, Y)
         m_precision_score = precision_score(Y_ref, Y)
         m_f1_score = f1_score(Y_ref, Y)
-    if len(np.unique(idx_out)) == 2:
+    if len(np.unique(Y)) == 2:
         m_roc_auc = roc_auc_score(Y_ref, Y)
     else:
         m_roc_auc = np.nan # ROC not defined in this case

--- a/freediscovery/utils.py
+++ b/freediscovery/utils.py
@@ -39,8 +39,8 @@ def categorization_score(idx_ref, Y_ref, idx, Y):
             roc_auc_score, average_precision_score)
     threshold = 0.0
 
-    idx = np.asarray(idx)
-    idx_ref = np.asarray(idx_ref)
+    idx = np.asarray(idx, dtype='int')
+    idx_ref = np.asarray(idx_ref, dtype='int')
     Y = np.asarray(Y)
     Y_ref = np.asarray(Y_ref)
 

--- a/freediscovery/utils.py
+++ b/freediscovery/utils.py
@@ -76,24 +76,6 @@ def classification_score(X_ref, Y_ref, X, Y):
             "f1": m_f1_score, 'roc_auc': m_roc_auc,
             'average_precision': m_average_precision }
 
-
-def filter_rel_nrel(self, relevant_filenames, non_relevant_filenames):
-    """Load features corresponding to a list of relevant / non relevant filenames
-    """
-    filenames_all, fset_all = self.fe.load(self.dsid)  #, mmap_mode='r')
-    idx_rel = self.fe.search(relevant_filenames)
-    idx_nrel = self.fe.search(non_relevant_filenames)
-    if idx_rel is None:
-        raise ValueError('No relevant files found with the input provided: {} ...!'.format(relevant_filenames[:20]))
-    if idx_nrel is None:
-        raise ValueError('No not-relevant files found with the input provided!')
-    d_rel = fset_all[idx_rel,:]
-    #print(idx_rel)
-    #print(type(fset_all.shape))
-    d_nrel = fset_all[idx_nrel,:]
-    return fset_all, idx_rel, idx_nrel, d_rel, d_nrel
-
-
 def _rename_main_thread():
     """
     This aims to address the fact that joblib wrongly detects uWSGI workers

--- a/freediscovery/utils.py
+++ b/freediscovery/utils.py
@@ -29,7 +29,7 @@ def _silent(stream='stderr'):
     setattr(sys, stream, stderr)
 
 
-def classification_score(X_ref, Y_ref, X, Y):
+def categorization_score(idx_ref, Y_ref, idx, Y):
     """ Calculate the efficiency scores """
     # This function should be deprecated
     # An equivalent functionally should be achieved with a
@@ -39,38 +39,43 @@ def classification_score(X_ref, Y_ref, X, Y):
             roc_auc_score, average_precision_score)
     threshold = 0.0
 
-    X_ref = np.asarray(X_ref)
-    X = np.asarray(X)
+    idx = np.asarray(idx)
+    idx_ref = np.asarray(idx_ref)
+    Y = np.asarray(Y)
+    Y_ref = np.asarray(Y_ref)
 
-    # this merge operation should not be necessary anymore once we move to the
-    # numeric indexing (issue #4)
-
-    d_pred = pd.DataFrame({'is_relevant_p': Y > threshold,
-                           'is_relevant_score': Y}, index=X)
-    d_ref = pd.DataFrame({'is_relevant': Y_ref}, index=X_ref)
-    d_out = pd.merge(d_ref, d_pred, how='inner', left_index=True, right_index=True)
-    if d_out.shape[0] == 0:
+    idx_out = np.intersect1d(idx_ref, idx)
+    if not len(idx_out):
         return {"recall_score": -1, "precision_score": -1, 'f1': -1, 'auc_roc': -1,
                 'average_precision': -1}
 
-    is_relevant = d_out.is_relevant.values
+    # sort values by index 
+    order_ref = idx_ref.argsort()
+    idx_ref = idx_ref[order_ref]
+    Y_ref = Y_ref[order_ref]
+
+    order = idx.argsort()
+    idx = idx[order]
+    Y = Y[order]
+
+    # find indices that are in both the reference and the test dataset
+    mask_ref = np.in1d(idx_ref, idx_out)
+    mask = np.in1d(idx, idx_out)
+
+    Y_ref = Y_ref[mask_ref]
+    Y = (Y > threshold)[mask]
+
     with warnings.catch_warnings():
         warnings.simplefilter("ignore", category=UndefinedMetricWarning)
 
-        m_recall_score = recall_score(is_relevant,
-                                      d_out.is_relevant_p.values)
-        m_precision_score = precision_score(d_out.is_relevant.values,
-                                            d_out.is_relevant_p.values)
-        m_f1_score = f1_score(is_relevant,
-                              d_out.is_relevant_p.values)
-    if len(np.unique(is_relevant)) == 2:
-        m_roc_auc = roc_auc_score(is_relevant,
-                                  d_out.is_relevant_score.values)
+        m_recall_score = recall_score(Y_ref, Y)
+        m_precision_score = precision_score(Y_ref, Y)
+        m_f1_score = f1_score(Y_ref, Y)
+    if len(np.unique(idx_out)) == 2:
+        m_roc_auc = roc_auc_score(Y_ref, Y)
     else:
         m_roc_auc = np.nan # ROC not defined in this case
-    m_average_precision = average_precision_score(
-                              is_relevant,
-                              d_out.is_relevant_score.values)
+    m_average_precision = average_precision_score(Y_ref, Y)
 
     return {"recall": m_recall_score, "precision": m_precision_score,
             "f1": m_f1_score, 'roc_auc': m_roc_auc,


### PR DESCRIPTION
This Pull Request addresses issue #4 and updates categorization and LSI modules to use numeric indexing instead of indexing by filenames,
  - adds a `GET /api/v0/feature-extraction/<dataset-id>/index` endpoint that returns a list of document ids given a list of file-names.
  - previously categorization and LSI accepted as input a list of relevant & non relevant file-names, which required to apply twice any operation on these lists. With this update, these methods take as input
       - a list of document ids (`index`)
       - target binary class relative to index (0 for non relevant or 1 for relevant)  (`y`)
    this result in a more consistent API with respect to other ML libraries, have a more direct correspondence to ground truth files, and simplify categorization / LSI modules  and examples. Also related to #20 .