### PR TITLE
Integration tests for models with and without hashed features

### DIFF
--- a/freediscovery/categorization.py
+++ b/freediscovery/categorization.py
@@ -69,8 +69,6 @@ class Categorizer(BaseEstimator):
             raise WrongParameter('dsid and mid')
 
         self.fe = FeatureVectorizer(cache_dir=cache_dir, dsid=dsid)
-        if not self.fe._pars['use_hashing']:
-            raise NotImplementedFD('Using categorisation without hashed features is not supported by FreeDiscovery at the moment!')
 
         self.model_dir = os.path.join(self.fe.cache_dir, dsid, self._DIRREF)
 
@@ -221,7 +219,7 @@ class Categorizer(BaseEstimator):
             'method': method,
             'index': index,
             'y': y
-        }
+            }
         pars['options'] = cmod.get_params()
         self._pars = pars
         joblib.dump(pars, os.path.join(mid_dir, 'pars'), compress=9)

--- a/freediscovery/cluster/base.py
+++ b/freediscovery/cluster/base.py
@@ -19,7 +19,7 @@ from .utils import _dbscan_noisy2unique
 
 
 ### Clustering methods for FreeDiscovery
-### This is highly inspired by the scikit example
+### This is highly inspired from the scikit-learn text clustering example
 
 MAX_N_TOP_WORDS = 1000
 
@@ -63,10 +63,6 @@ def _generate_lsi(lsi_components=None):
     else:
         lsi = None
     return lsi
-
-
-
-
 
 
 class ClusterLabels(object):

--- a/freediscovery/tests/test_integration.py
+++ b/freediscovery/tests/test_integration.py
@@ -1,0 +1,116 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+#from __future__ import unicode_literals
+
+import os.path
+from unittest import SkipTest
+
+import numpy as np
+from numpy.testing import assert_allclose, assert_equal
+
+import pytest
+import itertools
+
+from freediscovery.text import FeatureVectorizer
+from freediscovery.categorization import Categorizer
+from freediscovery.dupdet import DuplicateDetection
+from freediscovery.cluster import Clustering
+from freediscovery.lsi import LSI
+from freediscovery.io import parse_ground_truth_file
+from freediscovery.utils import categorization_score
+from freediscovery.exceptions import OptionalDependencyMissing
+from .run_suite import check_cache
+
+
+basename = os.path.dirname(__file__)
+data_dir = os.path.join(basename, "..", "data", "ds_001", "raw")
+
+
+@pytest.mark.parametrize('use_hashing, method', itertools.product([False, True],
+                                                ['Categorization', 'LSI',
+                                                 'DuplicateDetection', 'Clustering']))
+def test_features_hashing(use_hashing, method):
+    # check that models work both with and without hashing
+
+    cache_dir = check_cache()
+
+    n_features = 20000
+
+    fe = FeatureVectorizer(cache_dir=cache_dir)
+    uuid = fe.preprocess(data_dir, file_pattern='.*\d.txt', n_features=n_features,
+                         use_hashing=use_hashing)
+    uuid, filenames  = fe.transform()
+
+    ground_truth = parse_ground_truth_file(
+                            os.path.join(data_dir, "..", "ground_truth_file.txt"))
+
+
+    if method == 'Categorization':
+        cat = Categorizer(cache_dir=cache_dir, dsid=uuid, cv_n_folds=2)
+        index = cat.fe.search(ground_truth.index.values)
+
+        try:
+            coefs, Y_train = cat.train(
+                                    index,
+                                    ground_truth.is_relevant.values,
+                                    )
+        except OptionalDependencyMissing:
+            raise SkipTest
+
+        Y_pred = cat.predict()
+        X_pred = np.arange(cat.fe.n_samples_, dtype='int')
+        idx_gt = cat.fe.search(ground_truth.index.values)
+
+        scores = categorization_score(idx_gt,
+                            ground_truth.is_relevant.values,
+                            X_pred, Y_pred)
+        assert_allclose(scores['precision'], 1, rtol=0.5)
+        assert_allclose(scores['recall'], 1, rtol=0.5)
+        cat.delete()
+    elif method == 'LSI':
+        lsi = LSI(cache_dir=cache_dir, dsid=uuid)
+        lsi_res, exp_var = lsi.transform(n_components=100)  # TODO unused variables
+        lsi_id = lsi.mid
+        assert lsi.get_dsid(fe.cache_dir, lsi_id) == uuid
+        assert lsi.get_path(lsi_id) is not None
+        assert lsi._load_pars(lsi_id) is not None
+        lsi.load(lsi_id)
+
+        idx_gt = lsi.fe.search(ground_truth.index.values)
+        idx_all = np.arange(lsi.fe.n_samples_, dtype='int')
+
+        for accumulate in ['nearest-max', 'centroid-max']:
+                            #'nearest-diff', 'nearest-combine', 'stacking']:
+            _, Y_train, Y_pred, ND_train = lsi.predict(
+                                    idx_gt,
+                                    ground_truth.is_relevant.values,
+                                    accumulate=accumulate)
+            scores = categorization_score(idx_gt,
+                                ground_truth.is_relevant.values,
+                                idx_all, Y_pred)
+            assert_allclose(scores['precision'], 1, rtol=0.5)
+            assert_allclose(scores['recall'], 1, rtol=0.3)
+    elif method == 'DuplicateDetection':
+        dd = DuplicateDetection(cache_dir=cache_dir, dsid=uuid)
+        try:
+            dd.fit()
+        except ImportError:
+            raise SkipTest
+        cluster_id = dd.query(distance=10)
+    elif method =='Clustering':
+        if not use_hashing:
+            cat = Clustering(cache_dir=cache_dir, dsid=uuid)
+            cm = getattr(cat,'k_means')
+            labels, htree = cm(2, lsi_components=20)
+
+            terms = cat.compute_labels(n_top_words=10)
+        else:
+            with pytest.raises(NotImplementedError):
+                Clustering(cache_dir=cache_dir, dsid=uuid)
+
+
+    else:
+        raise ValueError

--- a/freediscovery/tests/test_server.py
+++ b/freediscovery/tests/test_server.py
@@ -197,8 +197,8 @@ def test_api_categorization(app, solver, cv):
 
     filenames = data['filenames']
     # we train the model on 5 samples / 6 and see what happens
-    index_filenames = filenames[:2] + filenames[3:]
-    y = [1, 1,  0, 0, 0]
+    index_filenames = filenames[:3] + filenames[3:]
+    y = [1, 1, 1,  0, 0, 0]
 
     method = V01 + "/feature-extraction/{}/index".format(dsid)
     res = app.get(method, data={'filenames': index_filenames})


### PR DESCRIPTION
This adds additional integration tests to constrain the behavior of different models when they are used with and without the hashed feature extraction (issue #11 ). 