### PR TITLE
Metrics

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,4 +40,4 @@ newsgroup_data/
 doc/modules/
 doc/examples/
 doc/generated/
-
+treclegal09*.tar.gz

--- a/examples/clustering_example.py
+++ b/examples/clustering_example.py
@@ -84,7 +84,7 @@ print("     => model id = {}".format(mid))
 
 print("\n2.b. Computing cluster labels")
 url = BASE_URL + '/clustering/k-mean/{}'.format(mid)
-print(" POST", url)
+print(" GET", url)
 res = requests.get(url,
                    json={'n_top_words': 6
                          }).json()
@@ -113,7 +113,7 @@ print("     => model id = {}".format(mid))
 
 print("\n3.b. Computing cluster labels")
 url = BASE_URL + '/clustering/ward_hc/{}'.format(mid)
-print("POST", url)
+print(" GET", url)
 res = requests.get(url,
                    json={'n_top_words': 6
                          }).json()

--- a/freediscovery/metrics.py
+++ b/freediscovery/metrics.py
@@ -39,11 +39,11 @@ def f1_same_duplicates_score(x, y):
     if x.shape != y.shape:
         raise ValueError
     x_dup = _dbscan_unique2noisy(x)
-    x_dup[x_dup > -1] = 1 # not a duplicate
-    x_dup[x_dup == -1] = 0 # not a duplicate
+    x_dup[x_dup > -1] = 1  # duplicates
+    x_dup[x_dup == -1] = 0  # not duplicates
     y_dup = _dbscan_unique2noisy(y)
-    y_dup[y_dup > -1] = 1 # not a duplicate
-    y_dup[y_dup == -1] = 0 # not a duplicate
+    y_dup[y_dup > -1] = 1  # duplicates
+    y_dup[y_dup == -1] = 0  # not duplicates
 
     x_dup = np.abs(x_dup)
     y_dup = np.abs(y_dup)

--- a/freediscovery/server/app.py
+++ b/freediscovery/server/app.py
@@ -17,7 +17,7 @@ from .resources import (FeaturesApi, FeaturesApiElement, FeaturesApiElementIndex
                         BirchClusteringApi, WardHCClusteringApi, DBSCANClusteringApi,
                         DupDetectionApi, DupDetectionApiElement,
                         DatasetsApiElement,
-                        MetricsCategorizationApiElement, MetricsClusteringApiElement  # MetricsDupDetectionApiElement
+                        MetricsCategorizationApiElement, MetricsClusteringApiElement, MetricsDupDetectionApiElement
                         )
 
 
@@ -63,6 +63,7 @@ def fd_app(cache_dir):
         (DupDetectionApiElement         , '/duplicate-detection/<mid>')            ,
         (MetricsCategorizationApiElement, '/metrics/categorization')               ,
         (MetricsClusteringApiElement    , '/metrics/clustering')                   ,
+        (MetricsDupDetectionApiElement  , '/metrics/duplicate-detection')
          #(CatchAll               , "/<url>")
                              ]:
         # monkeypatching, not great

--- a/freediscovery/server/app.py
+++ b/freediscovery/server/app.py
@@ -17,7 +17,7 @@ from .resources import (FeaturesApi, FeaturesApiElement, FeaturesApiElementIndex
                         BirchClusteringApi, WardHCClusteringApi, DBSCANClusteringApi,
                         DupDetectionApi, DupDetectionApiElement,
                         DatasetsApiElement,
-                        MetricsCategorizationApiElement  #, MetricsClusteringApiElement, MetricsDupDetectionApiElement
+                        MetricsCategorizationApiElement, MetricsClusteringApiElement  # MetricsDupDetectionApiElement
                         )
 
 
@@ -62,6 +62,7 @@ def fd_app(cache_dir):
         (DupDetectionApi                , '/duplicate-detection/')                 ,
         (DupDetectionApiElement         , '/duplicate-detection/<mid>')            ,
         (MetricsCategorizationApiElement, '/metrics/categorization')               ,
+        (MetricsClusteringApiElement    , '/metrics/clustering')                   ,
          #(CatchAll               , "/<url>")
                              ]:
         # monkeypatching, not great

--- a/freediscovery/server/app.py
+++ b/freediscovery/server/app.py
@@ -11,15 +11,13 @@ from flask_restful import Api, Resource
 from flask import jsonify
 
 from .resources import (FeaturesApi, FeaturesApiElement, FeaturesApiElementIndex,
-                        LsiApi, ModelsApi,
-                        ModelsApiElement, ModelsApiPredict,
-                        ModelsApiTest, LsiApiElement,
-                        LsiApiElementTest, LsiApiElementPredict,
+                        ModelsApi, ModelsApiElement, ModelsApiPredict, ModelsApiTest,
+                        LsiApi, LsiApiElement, LsiApiElementPredict, LsiApiElementTest,
                         ClusteringApiElement, KmeanClusteringApi,
-                        BirchClusteringApi, WardHCClusteringApi,
-                        DBSCANClusteringApi,
+                        BirchClusteringApi, WardHCClusteringApi, DBSCANClusteringApi,
                         DupDetectionApi, DupDetectionApiElement,
-                        DatasetsApiElement
+                        DatasetsApiElement,
+                        MetricsCategorizationApiElement  #, MetricsClusteringApiElement, MetricsDupDetectionApiElement
                         )
 
 
@@ -44,25 +42,26 @@ def fd_app(cache_dir):
 
     ## Actually setup the Api resource routing here
     for resource_el, url in [
-         (DatasetsApiElement      , "/datasets/<name>")                      ,
-         (FeaturesApi             , "/feature-extraction")                   ,
-         (FeaturesApiElement      , '/feature-extraction/<dsid>')            ,
-         (FeaturesApiElementIndex , '/feature-extraction/<dsid>/index'),
-         (ModelsApi               , '/categorization/')                      ,
-         (ModelsApiElement        , '/categorization/<mid>')                 ,
-         (ModelsApiPredict        , '/categorization/<mid>/predict')         ,
-         (ModelsApiTest           , "/categorization/<mid>/test")            ,
-         (LsiApi                  , '/lsi/')                                 ,
-         (LsiApiElement           , '/lsi/<mid>')                            ,
-         (LsiApiElementPredict    , '/lsi/<mid>/predict')                    ,
-         (LsiApiElementTest       , '/lsi/<mid>/test')                       ,
-         (KmeanClusteringApi      , '/clustering/k-mean/')                   ,
-         (BirchClusteringApi      , '/clustering/birch')                     ,
-         (WardHCClusteringApi     , '/clustering/ward_hc')                   ,
-         (DBSCANClusteringApi     , '/clustering/dbscan')                    ,
-         (ClusteringApiElement    , '/clustering/<method>/<mid>')            ,
-         (DupDetectionApi         , '/duplicate-detection/')                 ,
-         (DupDetectionApiElement  , '/duplicate-detection/<mid>')            ,
+        (DatasetsApiElement             , '/datasets/<name>')                      ,
+        (FeaturesApi                    , '/feature-extraction')                   ,
+        (FeaturesApiElement             , '/feature-extraction/<dsid>')            ,
+        (FeaturesApiElementIndex        , '/feature-extraction/<dsid>/index')      ,
+        (ModelsApi                      , '/categorization/')                      ,
+        (ModelsApiElement               , '/categorization/<mid>')                 ,
+        (ModelsApiPredict               , '/categorization/<mid>/predict')         ,
+        (ModelsApiTest                  , '/categorization/<mid>/test')            ,
+        (LsiApi                         , '/lsi/')                                 ,
+        (LsiApiElement                  , '/lsi/<mid>')                            ,
+        (LsiApiElementPredict           , '/lsi/<mid>/predict')                    ,
+        (LsiApiElementTest              , '/lsi/<mid>/test')                       ,
+        (KmeanClusteringApi             , '/clustering/k-mean/')                   ,
+        (BirchClusteringApi             , '/clustering/birch')                     ,
+        (WardHCClusteringApi            , '/clustering/ward_hc')                   ,
+        (DBSCANClusteringApi            , '/clustering/dbscan')                    ,
+        (ClusteringApiElement           , '/clustering/<method>/<mid>')            ,
+        (DupDetectionApi                , '/duplicate-detection/')                 ,
+        (DupDetectionApiElement         , '/duplicate-detection/<mid>')            ,
+        (MetricsCategorizationApiElement, '/metrics/categorization')               ,
          #(CatchAll               , "/<url>")
                              ]:
         # monkeypatching, not great

--- a/freediscovery/server/schemas.py
+++ b/freediscovery/server/schemas.py
@@ -124,3 +124,11 @@ class MetricsCategorizationSchema(Schema):
     recall = fields.Number()
     f1 = fields.Number()
     roc_auc = fields.Number()
+
+
+class MetricsClusteringSchema(Schema):
+    adjusted_rand = fields.Number()
+    adjusted_mutual_info = fields.Number()
+    v_measure = fields.Number()
+    # silhouette = fields.Number()  TODO (X, labels), not (labels_true, labels_pred)
+

--- a/freediscovery/server/schemas.py
+++ b/freediscovery/server/schemas.py
@@ -50,9 +50,12 @@ class FeaturesSchema(FeaturesParsSchema):
     id = fields.Str(required=True)
     filenames = fields.List(fields.Str())
 
+
 class FeaturesElementIndexSchema(Schema):
     index = fields.List(fields.Int(), required=True)
 
+
+# TODO to delete after successful implementation of metrics
 class ClassificationScoresSchema(Schema):
     precision = fields.Number(required=True)
     recall = fields.Number(required=True)
@@ -114,3 +117,10 @@ class DuplicateDetectionSchema(Schema):
 
 class ErrorSchema(Schema):
     message = fields.Str(required=True)
+
+
+class MetricsCategorizationSchema(Schema):
+    precision = fields.Number()
+    recall = fields.Number()
+    f1 = fields.Number()
+    roc_auc = fields.Number()

--- a/freediscovery/server/schemas.py
+++ b/freediscovery/server/schemas.py
@@ -130,5 +130,9 @@ class MetricsClusteringSchema(Schema):
     adjusted_rand = fields.Number()
     adjusted_mutual_info = fields.Number()
     v_measure = fields.Number()
-    # silhouette = fields.Number()  TODO (X, labels), not (labels_true, labels_pred)
 
+
+class MetricsDupDetectionSchema(Schema):
+    ratio_duplicates = fields.Number()
+    f1_same_duplicates = fields.Number()
+    mean_duplicates_count = fields.Number()

--- a/freediscovery/tests/test_server.py
+++ b/freediscovery/tests/test_server.py
@@ -440,3 +440,30 @@ def test_exception_handling(app_notest):
     assert res.status_code in [500, 422]
     assert sorted(data.keys()) == ['messages']
     #assert 'ValueError' in data['message'] # check that the error message has the traceback
+
+
+
+@pytest.mark.parametrize('metrics',
+                         itertools.combinations(['precision', 'recall', 'f1', 'roc_auc'], 3))
+def test_metrics_get(app, metrics):
+    from sklearn.metrics import precision_score, recall_score, f1_score, roc_auc_score
+    metrics = list(metrics)
+    # print("METRICS:", metrics)
+    url = V01 + '/metrics/categorization'
+    y_true = [0, 0, 0, 1, 1, 0, 1, 0]
+    y_pred = [0, 0, 1, 1, 1, 0, 1, 1]
+
+    pars = {'y_true': y_true, 'y_pred': y_pred, 'metrics': metrics}
+    res = app.get(url, data=pars)
+    assert res.status_code == 200
+
+    data = parse_res(res)
+    assert sorted(data.keys()) == sorted(metrics)
+    if 'precision' in metrics:
+        assert data['precision'] == precision_score(y_true, y_pred)  # 0.6
+    if 'recall' in metrics:
+        assert data['recall'] == recall_score(y_true, y_pred)  # 1.0
+    if 'f1' in metrics:
+        assert data['f1'] == f1_score(y_true, y_pred)  # 0.75
+    if 'roc_auc' in metrics:
+        assert data['roc_auc'] == roc_auc_score(y_true, y_pred) # 0.8

--- a/freediscovery/tests/test_server.py
+++ b/freediscovery/tests/test_server.py
@@ -15,7 +15,7 @@ from ..server import fd_app
 from ..utils import _silent
 from ..exceptions import OptionalDependencyMissing
 from .run_suite import check_cache
-from numpy.testing import assert_equal
+from numpy.testing import assert_equal, assert_almost_equal
 
 V01 = '/api/v0'
 
@@ -446,9 +446,7 @@ def test_exception_handling(app_notest):
 @pytest.mark.parametrize('metrics',
                          itertools.combinations(['precision', 'recall', 'f1', 'roc_auc'], 3))
 def test_metrics_get(app, metrics):
-    from sklearn.metrics import precision_score, recall_score, f1_score, roc_auc_score
     metrics = list(metrics)
-    # print("METRICS:", metrics)
     url = V01 + '/metrics/categorization'
     y_true = [0, 0, 0, 1, 1, 0, 1, 0]
     y_pred = [0, 0, 1, 1, 1, 0, 1, 1]
@@ -460,10 +458,10 @@ def test_metrics_get(app, metrics):
     data = parse_res(res)
     assert sorted(data.keys()) == sorted(metrics)
     if 'precision' in metrics:
-        assert data['precision'] == precision_score(y_true, y_pred)  # 0.6
+        assert_almost_equal(data['precision'], 0.6)
     if 'recall' in metrics:
-        assert data['recall'] == recall_score(y_true, y_pred)  # 1.0
+        assert_almost_equal(data['recall'], 1.0)
     if 'f1' in metrics:
-        assert data['f1'] == f1_score(y_true, y_pred)  # 0.75
+        assert_almost_equal(data['f1'], 0.75)
     if 'roc_auc' in metrics:
-        assert data['roc_auc'] == roc_auc_score(y_true, y_pred) # 0.8
+        assert_almost_equal(data['roc_auc'], 0.8)

--- a/freediscovery/tests/test_server.py
+++ b/freediscovery/tests/test_server.py
@@ -445,7 +445,7 @@ def test_exception_handling(app_notest):
 
 @pytest.mark.parametrize('metrics',
                          itertools.combinations(['precision', 'recall', 'f1', 'roc_auc'], 3))
-def test_metrics_get(app, metrics):
+def test_categorization_metrics_get(app, metrics):
     metrics = list(metrics)
     url = V01 + '/metrics/categorization'
     y_true = [0, 0, 0, 1, 1, 0, 1, 0]
@@ -465,3 +465,25 @@ def test_metrics_get(app, metrics):
         assert_almost_equal(data['f1'], 0.75)
     if 'roc_auc' in metrics:
         assert_almost_equal(data['roc_auc'], 0.8)
+
+
+@pytest.mark.parametrize('metrics',
+                         itertools.combinations(['adjusted_rand', 'adjusted_mutual_info', 'v_measure'], 2))
+def test_clustering_metrics_get(app, metrics):
+    metrics = list(metrics)
+    url = V01 + '/metrics/clustering'
+    labels_true = [0, 0, 1, 2]
+    labels_pred = [0, 0, 1, 1]
+
+    pars = {'labels_true': labels_true, 'labels_pred': labels_pred, 'metrics': metrics}
+    res = app.get(url, data=pars)
+    assert res.status_code == 200
+
+    data = parse_res(res)
+    assert sorted(data.keys()) == sorted(metrics)
+    if 'adjusted_rand' in metrics:
+        assert_almost_equal(data['adjusted_rand'], 0.5714, decimal=4)
+    if 'adjusted_mutual_info' in metrics:
+        assert_almost_equal(data['adjusted_mutual_info'], 0.4)
+    if 'v_measure' in metrics:
+        assert_almost_equal(data['v_measure'], 0.8)


### PR DESCRIPTION
This PR adds 3 new API endpoints to calculate the following metrics:

1. Categorization (metrics from scikit-learn)

- precision
- recall
- f1_score
- roc_auc

2. Clustering (metrics from scikit-learn)

- adjusted_rand
- assert_almost_equal
- v_measure

3. Duplicate detection (metrics implemented before in metrics.py)

- ratio_duplicates
- f1_same_duplicates
- mean_duplicates_count