### PR TITLE
Downsampling  / upsampling of the extracted features

### DIFF
--- a/freediscovery/base.py
+++ b/freediscovery/base.py
@@ -103,8 +103,7 @@ class _BaseTextTransformer(object):
         return pars
 
     def search(self, filenames):
-        """ Return the document ids that correspond to the provided filenames,
-        without preserving order.
+        """ Return the document ids that correspond to the provided filenames.
 
         Parameters
         ----------


### PR DESCRIPTION
This PR adds a private `_FeatureVectorizerSampled` class, on top of  [`FeatureVectorizer`](https://github.com/rth/FreeDiscovery/blob/d38fff87bf621489fa8f6ea3b1d33acba8db062d/freediscovery/text.py#L55) that can be used to downsample  / upsample the extracted features. Mostly useful for internal testing and experimenting in the context of binary classification.