### PR TITLE
Adding a parser for RCV1 SMART stemmed format

### DIFF
--- a/freediscovery/io.py
+++ b/freediscovery/io.py
@@ -20,6 +20,24 @@ def parse_ground_truth_file(filename):
 
 
 def parse_smart_tokens(text):
+    """
+    Parse a dataset stored in the SMART tokenized format, used
+    in particular for the RCV1-v2 dataset,
+       http://www.jmlr.org/papers/volume5/lewis04a/lyrl2004_rcv1v2_README.htm
+    (cf. Appendix B.12.i.)
+
+    Parameters
+    ----------
+    text : str
+       the full text of the dataset
+
+
+    Returns
+    -------
+    result : dict
+       the parsed dataset in a OrderedDict, with document_ids as keys,
+       and a string of tokens as values
+    """
 
     res = OrderedDict()
 

--- a/freediscovery/io.py
+++ b/freediscovery/io.py
@@ -7,6 +7,7 @@ from __future__ import unicode_literals
 
 import pandas
 import platform
+from collections import OrderedDict
 
 
 def parse_ground_truth_file(filename):
@@ -16,3 +17,29 @@ def parse_ground_truth_file(filename):
     if platform.system() == 'Windows':
         df.index = df.index.map(lambda path: path.replace('/', '\\'))
     return df
+
+
+def parse_smart_tokens(text):
+
+    res = OrderedDict()
+
+    docid = None
+    document_text = []
+
+    for line in text.splitlines():
+        if line.startswith('.I'):
+            if docid is not None:
+                res[docid] = document_text
+            document_text = []
+            _, docid = line.split(' ')
+        elif line.startswith('.W') or not line:
+            pass
+        else:
+            document_text += line.split(' ')
+
+    if document_text and docid is not None:
+        res[docid] = document_text
+
+    return res
+
+

--- a/freediscovery/io.py
+++ b/freediscovery/io.py
@@ -19,7 +19,7 @@ def parse_ground_truth_file(filename):
     return df
 
 
-def parse_smart_tokens(text):
+def parse_rcv1_smart_tokens(text):
     """
     Parse a dataset stored in the SMART tokenized format, used
     in particular for the RCV1-v2 dataset,

--- a/freediscovery/tests/test_io.py
+++ b/freediscovery/tests/test_io.py
@@ -7,7 +7,8 @@ from __future__ import print_function
 import os.path
 from numpy.testing import assert_allclose
 
-from freediscovery.io import parse_ground_truth_file, parse_smart_tokens
+from freediscovery.io import (parse_ground_truth_file,
+                              parse_rcv1_smart_tokens)
 
 
 def test_parse_ground_truth_file():
@@ -31,7 +32,7 @@ def test_parse_smart_stemmed():
     sunday won race race andret andret rahal bobby lola lola ford ford reynard merced christ benz motor fittipald grand prix finish finish michael win vancouv vancouv indycar indycar
     """)
 
-    res = parse_smart_tokens(text)
+    res = parse_rcv1_smart_tokens(text)
     assert list(res.keys()) == ['26187', '26188']
     assert len(res['26188']) == 28
     res_ref = ['sunday', 'won', 'race', 'race', 'andret', 'andret', 'rahal',

--- a/freediscovery/tests/test_io.py
+++ b/freediscovery/tests/test_io.py
@@ -34,3 +34,9 @@ def test_parse_smart_stemmed():
     res = parse_smart_tokens(text)
     assert list(res.keys()) == ['26187', '26188']
     assert len(res['26188']) == 28
+    res_ref = ['sunday', 'won', 'race', 'race', 'andret', 'andret', 'rahal',
+               'bobby', 'lola', 'lola', 'ford', 'ford', 'reynard', 'merced',
+               'christ', 'benz', 'motor', 'fittipald', 'grand', 'prix',
+               'finish', 'finish', 'michael', 'win', 'vancouv', 'vancouv',
+               'indycar', 'indycar']
+    assert res['26188'] == res_ref

--- a/freediscovery/tests/test_io.py
+++ b/freediscovery/tests/test_io.py
@@ -3,10 +3,11 @@
 from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
+
 import os.path
 from numpy.testing import assert_allclose
 
-from freediscovery.io import parse_ground_truth_file
+from freediscovery.io import parse_ground_truth_file, parse_smart_tokens
 
 
 def test_parse_ground_truth_file():
@@ -14,3 +15,22 @@ def test_parse_ground_truth_file():
     filename = os.path.join(basename, "..","data", "ds_001", "ground_truth_file.txt")
     res = parse_ground_truth_file(filename)
     assert_allclose(res.values[:,0] , [1, 1, 1, 0, 0, 0])
+
+
+def test_parse_smart_stemmed():
+    from textwrap import dedent
+    text = dedent("""\
+    .I 26187
+    .W
+    sunday complet tabulat race race race top top andret brazil brazil brazil rahal bobby lola lola lola cosworth cosworth cosworth cosworth ford ford ford ford mph reynard reynard reynard reynard
+    reynard reynard merced merced merced christ benz benz benz motor motor fittipald jimmy vass al uns grand prix finish finish countr chass gil fer pensk bryan hert michael adrian gordon goodyear
+    lap robby driv kph canad hond hond hond vancouv vancouv de indycar indycar scot fernandez jr
+
+    .I 26188
+    .W
+    sunday won race race andret andret rahal bobby lola lola ford ford reynard merced christ benz motor fittipald grand prix finish finish michael win vancouv vancouv indycar indycar
+    """)
+
+    res = parse_smart_tokens(text)
+    assert list(res.keys()) == ['26187', '26188']
+    assert len(res['26188']) == 28


### PR DESCRIPTION
This PR adds a parser for the SMART stemmed format, used in particular for the RCV1-v2 dataset.