### PR TITLE
Refactoring nearest-neighbor categorization with LSI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,8 +9,6 @@ matrix:
       env: SKLEARN="0.18.1"
     - python: "2.7" 
       env: SKLEARN="0.18.1"
-    - python: "3.5"
-      env: SKLEARN="0.17.1"
 
 # setup adapted from https://github.com/soft-matter/trackpy/blob/master/.travis.yml
 before_install:

--- a/doc/rest_api/lsi_predict_post.md
+++ b/doc/rest_api/lsi_predict_post.md
@@ -10,10 +10,11 @@
 
  * **Success Response**: `HTTP 200`
     
-        {"id": <str>, "recall": <float>, "precision": <float> , 
-         "f1": <float>,  "roc_auc": <float>, "average_precision": <float>,
-         "prediction": <list[float]> ,
-         "prediction_rel": <list[float]> ,
-         "prediction_nrel": <list[float]> ,
-         "nearest_rel_doc": <list[int]> ,
-         "nearest_nrel_doc": <list[int]> }
+        { "id": <str>, "prediction": <list[float]> ,
+         "dist_p": <list[float]> ,
+         "dist_n": <list[float]> ,
+         "ind_p": <list[int]> ,
+         "ind_n": <list[int]>
+         "scores":  {"recall": <float>, "precision": <float> , 
+                    "f1": <float>,  "roc_auc": <float>, "average_precision": <float>}
+         }

--- a/examples/categorization_example.py
+++ b/examples/categorization_example.py
@@ -164,8 +164,8 @@ if __name__ == '__main__':
                               }).json()
     prediction = res['prediction']
 
-    print('    => Training scores: MAP = {average_precision:.3f}, ROC-AUC = {roc_auc:.3f}'.format(**res))
-    df = pd.DataFrame({key: res[key] for key in res if 'prediction'==key or 'nearest' in key})
+    print('    => Training scores: MAP = {average_precision:.3f}, ROC-AUC = {roc_auc:.3f}'.format(**res['scores']))
+    df = pd.DataFrame({key: res[key] for key in res if key not in ['id', 'scores']})
 
 
     print("\n3.c. Test categorization with LSI")

--- a/freediscovery/base.py
+++ b/freediscovery/base.py
@@ -13,6 +13,34 @@ from .exceptions import ModelNotFound
 from .exceptions import (DatasetNotFound, InitException, NotFound, WrongParameter)
 
 
+class RankerMixin(object):
+    """Mixin class for all ranking estimators in FreeDiscovery.
+    A ranker is a binary classifier without a decision threshold.
+    """
+    _estimator_type = "classifier"  # so that thing would still work with scikit learn
+
+    def score(self, X, y, sample_weight=None):
+        """Returns the ROC score of the prediction.
+        Best possible score is 1.0 and the worst in 0.
+
+        Parameters
+        ----------
+        X : array-like, shape = (n_samples, n_features)
+            Test samples.
+        y : array-like, shape = (n_samples)
+            True values for X.
+        sample_weight : array-like, shape = [n_samples], optional
+            Sample weights.
+        Returns
+        -------
+        score : float
+            ROC score of self.decision_function(X) wrt. y.
+        """
+
+        from .metrics import roc_auc_score
+        return roc_auc_score(y, self.decision_function(X), sample_weight=sample_weight,)
+
+
 class _BaseTextTransformer(object):
     """Base text transformer
 

--- a/freediscovery/base.py
+++ b/freediscovery/base.py
@@ -17,7 +17,7 @@ class RankerMixin(object):
     """Mixin class for all ranking estimators in FreeDiscovery.
     A ranker is a binary classifier without a decision threshold.
     """
-    _estimator_type = "classifier"  # so that thing would still work with scikit learn
+    _estimator_type = "ranker"  # so that thing would still work with scikit learn
 
     def score(self, X, y, sample_weight=None):
         """Returns the ROC score of the prediction.

--- a/freediscovery/categorization.py
+++ b/freediscovery/categorization.py
@@ -82,7 +82,7 @@ class NearestNeighborRanker(BaseEstimator, RankerMixin):
     def __init__(self, n_neighbors=1, radius=1.0,
                  algorithm='ball_tree', leaf_size=30, n_jobs=1, **kwargs):
 
-        # define nearest neighbors search for positive and negative samples
+        # define nearest neighbors search objects for positive and negative samples
         self._mod_p = NearestNeighbors(n_neighbors=1,
                                        leaf_size=leaf_size,
                                        algorithm=algorithm,
@@ -112,7 +112,7 @@ class NearestNeighborRanker(BaseEstimator, RankerMixin):
         -------
         score : array (n_samples,)
            the ranking score in the range [-1, 1]
-           For postive items score = 1 - cosine distance / 2
+           For positive items score = 1 - cosine distance / 2
         """
         # convert from eucledian distance in L2 norm space to cosine similarity
         S_p = 1 - d_p/2

--- a/freediscovery/categorization.py
+++ b/freediscovery/categorization.py
@@ -10,9 +10,12 @@ import numpy as np
 import scipy
 from scipy.special import logit
 from sklearn.externals import joblib
+from sklearn.neighbors import NearestNeighbors
+from sklearn.utils.validation import check_array
+
 
 from .text import FeatureVectorizer
-from .base import BaseEstimator
+from .base import BaseEstimator, RankerMixin
 from .utils import setup_model, _rename_main_thread
 from .exceptions import (ModelNotFound, WrongParameter, NotImplementedFD, OptionalDependencyMissing)
 
@@ -26,12 +29,174 @@ def _zip_relevant(relevant_id, non_relevant_id):
     return idx_id, y
 
 def _unzip_relevant(idx_id, y):
-    """ Take an array of indices and prediction values and return
+    """Take an array of indices and prediction values and return
     a list of relevant and non relevant documents id
+
+    Parameters
+    ----------
+    idx_id : ndarray[int] (n_samples)
+        array of indices
+    y : ndarray[float] (n_samples)
+        target array
     """
     mask = np.asarray(y) > 0.5
     idx_id = np.asarray(idx_id, dtype='int')
     return idx_id[mask], idx_id[~mask]
+
+
+class NearestNeighborRanker(BaseEstimator, RankerMixin):
+    """A nearest neighbor ranker, behaves like
+        * KNeigborsClassifier (supervised) when trained on both positive and negative samples
+        * NearestNeighbors  (unsupervised) when trained on positive samples only
+
+    Parameters
+    ----------
+    radius : float, optional (default = 1.0)
+        Range of parameter space to use by default for :meth:`radius_neighbors`
+        queries.
+
+    algorithm : {'auto', 'ball_tree', 'kd_tree', 'brute'}, optional
+        Algorithm used to compute the nearest neighbors:
+
+        - 'ball_tree' will use :class:`BallTree`
+        - 'kd_tree' will use :class:`KDtree`
+        - 'brute' will use a brute-force search.
+        - 'auto' will attempt to decide the most appropriate algorithm
+          based on the values passed to :meth:`fit` method.
+
+        Note: fitting on sparse input will override the setting of
+        this parameter, using brute force.
+
+    leaf_size : int, optional (default = 30)
+        Leaf size passed to BallTree or KDTree.  This can affect the
+        speed of the construction and query, as well as the memory
+        required to store the tree.  The optimal value depends on the
+        nature of the problem.
+
+    n_jobs : int, optional (default = 1)
+        The number of parallel jobs to run for neighbors search.
+        If ``-1``, then the number of jobs is set to the number of CPU cores.
+
+    """
+
+    def __init__(self, n_neighbors=1, radius=1.0,
+                 algorithm='ball_tree', leaf_size=30, n_jobs=1, **kwargs):
+
+        # define nearest neighbors search for positive and negative samples
+        self._mod_p = NearestNeighbors(n_neighbors=1,
+                                       leaf_size=leaf_size,
+                                       algorithm=algorithm,
+                                       n_jobs=n_jobs,
+                                       metric='euclidean',  # euclidean metric by default
+                                       **kwargs)
+        self._mod_n = NearestNeighbors(n_neighbors=1,
+                                       leaf_size=leaf_size,
+                                       algorithm=algorithm,
+                                       n_jobs=n_jobs,
+                                       metric='euclidean',  # euclidean metric by default
+                                       **kwargs)
+
+    @staticmethod
+    def _ranking_score(d_p, d_n=None):
+        """ Compute the ranking score from the positive an negative
+        distances on L2 normalized data
+
+        Parameters
+        ----------
+        d_p : array (n_samples,)
+           distance to the positive samples
+        d_n : array (n_samples,)
+           (optional) distance to the negative samples
+
+        Returns
+        -------
+        score : array (n_samples,)
+           the ranking score in the range [-1, 1]
+           For postive items score = 1 - cosine distance / 2
+        """
+        # convert from eucledian distance in L2 norm space to cosine similarity
+        S_p = 1 - d_p/2
+        if d_n is not None:
+            S_n = 1 - d_n/2
+            return np.where(S_p > S_n,
+                            S_p + 1,
+                            -1 - S_n) / 2
+        else:
+            return (S_p + 1) / 2
+
+    def fit(self, X, y):
+        """Fit the model using X as training data
+        Parameters
+        ----------
+        X : {array-like, sparse matrix, BallTree, KDTree}
+            Training data, shape [n_samples, n_features],
+
+        """
+        X = check_array(X, accept_sparse='csr')
+
+        index = np.arange(X.shape[0], dtype='int')
+
+        self._index_p, self._index_n = _unzip_relevant(index, y)
+
+
+        if self._index_p.shape[0] > 0:
+            self._mod_p.fit(X[self._index_p])
+        else:
+            raise ValueError('Training sets with no positive labels are not supported!')
+        if self._index_n.shape[0] > 0:
+            self._mod_n.fit(X[self._index_n])
+        else:
+            pass
+
+    def kneighbors(self, X=None):
+        """Finds the K-neighbors of a point.
+        Returns indices of and distances to the neighbors of each point.
+        Parameters
+        ----------
+        X : array-like, shape (n_samples, n_features)
+            the input array
+        Returns
+        -------
+        score : array
+            ranking score (based on cosine similarity)
+        ind : array
+            Indices of the nearest points in the population matrix.
+        md : dict
+            Additional result data
+              * ind_p : Indices of the nearest positive points
+              * ind_n : Indices of the nearest negate points
+              * dist_p : distance to the nearest positive points
+              * dist_n : distance to the nearest negate points
+        --------
+        """
+        X = check_array(X, accept_sparse='csr')
+
+        D_p, idx_p_loc = self._mod_p.kneighbors(X)
+
+        # only NearestNeighbor-1 (only one column in the kneighbors output)
+        D_p = D_p[:,0]
+        # map local index within _index_p, _index_n to global index
+        ind_p = self._index_p[idx_p_loc[:,0]]
+
+        md = {'dist_p': D_p,
+              'ind_p': ind_p,
+             }
+
+        if self._mod_n._fit_method is not None:
+            D_n, idx_n_loc = self._mod_n.kneighbors(X)
+            D_n = D_n[:,0]
+            ind_n = self._index_n[idx_n_loc[:,0]]
+            md['ind_n'] = ind_n
+            md['dist_n'] = D_n
+            ind = np.where(D_p <= D_n, ind_p, ind_n)
+        else:
+            D_n = None
+            ind = ind_p
+
+        score = self._ranking_score(D_p, D_n)
+
+        return  score, ind , md
+
 
 
 class Categorizer(BaseEstimator):

--- a/freediscovery/lsi.py
+++ b/freediscovery/lsi.py
@@ -16,7 +16,7 @@ from sklearn.utils.sparsefuncs import mean_variance_axis
 from sklearn.decomposition import TruncatedSVD
 
 from .text import FeatureVectorizer
-from .base import BaseEstimator
+from .base import BaseEstimator, BaseRegressor
 from .categorization import _unzip_relevant
 from .utils import setup_model
 from .exceptions import (WrongParameter, NotImplementedFD)

--- a/freediscovery/lsi.py
+++ b/freediscovery/lsi.py
@@ -16,7 +16,7 @@ from sklearn.utils.sparsefuncs import mean_variance_axis
 from sklearn.decomposition import TruncatedSVD
 
 from .text import FeatureVectorizer
-from .base import BaseEstimator, BaseRegressor
+from .base import BaseEstimator
 from .categorization import _unzip_relevant
 from .utils import setup_model
 from .exceptions import (WrongParameter, NotImplementedFD)

--- a/freediscovery/lsi.py
+++ b/freediscovery/lsi.py
@@ -167,9 +167,9 @@ class LSI(BaseEstimator):
             ds_p = lsi.transform_lsi_norm(ds[mslice, :])
             out = {}
             for key, val in _query.items():
-                D_tmp = val.dot(ds_p.T).T
-                out['idx_'+key] = np.argmax(D_tmp, axis=1)
-                out['D_'+key] = np.max(D_tmp, axis=1)
+                D_tmp = 1 - val.dot(ds_p.T).T
+                out['idx_'+key] = np.argmin(D_tmp, axis=1)
+                out['D_'+key] = np.min(D_tmp, axis=1)
             return out
 
         res = {}
@@ -187,7 +187,7 @@ class LSI(BaseEstimator):
         
         D_rel = res['D_d_p']
         D_nrel = res['D_d_n']
-        D_max = np.where(D_rel > D_nrel, D_rel, - D_nrel)
+        D_max = np.where(D_rel < D_nrel, 1 - D_rel, - (1 - D_nrel))
         D_diff = D_rel - D_nrel
         if method == 'nearest-neighbor-1':
             D = D_max

--- a/freediscovery/lsi.py
+++ b/freediscovery/lsi.py
@@ -119,7 +119,7 @@ class LSI(BaseEstimator):
 
         return lsi, exp_var
 
-    def predict(self, index, y, method='nearest-max', chunk_size=100):
+    def predict(self, index, y, method='nearest-neighbor-1', chunk_size=100):
         """
         Predict the document relevance using a previously trained LSI model
 
@@ -129,14 +129,14 @@ class LSI(BaseEstimator):
            document indices of the training set
         y : array-like, shape (n_samples)
            target binary class relative to index
-        method : str, optional, default='nearest-max'
-           if `method=="nearest-max"` the cosine distance to the closest relevant/non relevant document is used as classification score,
-           otherwise if `method=="centroid-max"` the centroid of relevant documents is used as the query vector.
+        method : str, optional, default='nearest-neighbor-1'
+           if `method=="nearest-neighbor-1"` the cosine distance to the closest relevant/non relevant document is used as classification score,
+           otherwise if `method=="nearest-centroid"` the centroid of relevant documents is used as the query vector.
 
         """
-        if method in ['centroid-max', 'nearest-max']:
+        if method in ['nearest-centroid', 'nearest-neighbor-1']:
             pass
-        elif method in ['nearest-diff', 'nearest-combine', 'stacking']:
+        elif method in ['nearest-neighbor-diff', 'nearest-neighbor-combine', 'stacking']:
             raise WrongParameter('method = {} is implemented but is not production ready and was disabled for v0.5 release'.format(method))
         else:
             raise NotImplementedFD() 
@@ -189,13 +189,13 @@ class LSI(BaseEstimator):
         D_nrel = res['D_d_n']
         D_max = np.where(D_rel > D_nrel, D_rel, - D_nrel)
         D_diff = D_rel - D_nrel
-        if method == 'nearest-max':
+        if method == 'nearest-neighbor-1':
             D = D_max
-        elif method == 'nearest-diff':
+        elif method == 'nearest-neighbor-diff':
             D = D_diff
-        elif method == "nearest-combine":
+        elif method == "nearest-neighbor-combine":
             D = D_max*abs(D_diff)
-        elif method == 'centroid-max':
+        elif method == 'nearest-centroid':
             D = res['D_centr_p']
         elif method == 'stacking':
             from .private import lsi_stacking

--- a/freediscovery/lsi.py
+++ b/freediscovery/lsi.py
@@ -197,9 +197,6 @@ class LSI(BaseEstimator):
             D = D_max*abs(D_diff)
         elif method == 'nearest-centroid':
             D = res['D_centr_p']
-        elif method == 'stacking':
-            from .private import lsi_stacking
-            D = lsi_stacking(res, y, index)
         else:
             raise NotImplementedFD('method={} not supported!'.format(method))
         Y_train = D[index]

--- a/freediscovery/lsi.py
+++ b/freediscovery/lsi.py
@@ -119,7 +119,7 @@ class LSI(BaseEstimator):
 
         return lsi, exp_var
 
-    def predict(self, index, y, accumulate='nearest-max', chunk_size=100):
+    def predict(self, index, y, method='nearest-max', chunk_size=100):
         """
         Predict the document relevance using a previously trained LSI model
 
@@ -129,15 +129,15 @@ class LSI(BaseEstimator):
            document indices of the training set
         y : array-like, shape (n_samples)
            target binary class relative to index
-        accumulate : str, optional, default='nearest-max'
-           if `accumulate=="nearest-max"` the cosine distance to the closest relevant/non relevant document is used as classification score,
-           otherwise if `accumulate=="centroid-max"` the centroid of relevant documents is used as the query vector.
+        method : str, optional, default='nearest-max'
+           if `method=="nearest-max"` the cosine distance to the closest relevant/non relevant document is used as classification score,
+           otherwise if `method=="centroid-max"` the centroid of relevant documents is used as the query vector.
 
         """
-        if accumulate in ['centroid-max', 'nearest-max']:
+        if method in ['centroid-max', 'nearest-max']:
             pass
-        elif accumulate in ['nearest-diff', 'nearest-combine', 'stacking']:
-            raise WrongParameter('accumulate = {} is implemented but is not production ready and was disabled for v0.5 release'.format(accumulate))
+        elif method in ['nearest-diff', 'nearest-combine', 'stacking']:
+            raise WrongParameter('method = {} is implemented but is not production ready and was disabled for v0.5 release'.format(method))
         else:
             raise NotImplementedFD() 
 
@@ -189,19 +189,19 @@ class LSI(BaseEstimator):
         D_nrel = res['D_d_n']
         D_max = np.where(D_rel > D_nrel, D_rel, - D_nrel)
         D_diff = D_rel - D_nrel
-        if accumulate == 'nearest-max':
+        if method == 'nearest-max':
             D = D_max
-        elif accumulate == 'nearest-diff':
+        elif method == 'nearest-diff':
             D = D_diff
-        elif accumulate == "nearest-combine":
+        elif method == "nearest-combine":
             D = D_max*abs(D_diff)
-        elif accumulate == 'centroid-max':
+        elif method == 'centroid-max':
             D = res['D_centr_p']
-        elif accumulate == 'stacking':
+        elif method == 'stacking':
             from .private import lsi_stacking
             D = lsi_stacking(res, y, index)
         else:
-            raise NotImplementedFD('accumulate={} not supported!'.format(accumulate))
+            raise NotImplementedFD('method={} not supported!'.format(method))
         Y_train = D[index]
         Y_test = D[:]
 

--- a/freediscovery/server/resources.py
+++ b/freediscovery/server/resources.py
@@ -218,7 +218,7 @@ class LsiApiElementPredict(Resource):
     def post(self, mid, **args):
         lsi = LSI(self._cache_dir, mid=mid)
         _, Y_train, Y_test, res  = lsi.predict(
-                method='nearest-max', **args) 
+                method='nearest-neighbor-1', **args)
 
         idx_train = args['index']
         y = args['y']
@@ -249,7 +249,7 @@ class LsiApiElementTest(Resource):
         d_ref = parse_ground_truth_file(args["ground_truth_filename"])
         del args['ground_truth_filename']
         lsi_m, Y_train, Y_test, res  = lsi.predict(
-                method='nearest-max', **args) 
+                method='nearest-neighbor-1', **args)
 
         idx_ref = lsi.fe.search(d_ref.index.values)
 

--- a/freediscovery/server/resources.py
+++ b/freediscovery/server/resources.py
@@ -217,20 +217,16 @@ class LsiApiElementPredict(Resource):
     @marshal_with(LsiPredictSchema())
     def post(self, mid, **args):
         lsi = LSI(self._cache_dir, mid=mid)
-        _, Y_train, Y_test, res  = lsi.predict(
+        _, Y_train, Y_test, md  = lsi.predict(
                 method='nearest-neighbor-1', **args)
 
         idx_train = args['index']
         y = args['y']
 
-        res_scores = categorization_score(idx_train, y, idx_train, Y_train)
-        res_scores.update({'prediction': Y_test.tolist(),
-                    'prediction_rel': res['D_d_p'].tolist(),
-                    'prediction_nrel': res['D_d_n'].tolist(),
-                    'nearest_rel_doc': res['idx_d_p'].tolist(),
-                    'nearest_nrel_doc': res['idx_d_n'].tolist(),
-                     })
-        return res_scores
+        res = {'prediction': Y_test.tolist()}
+        res['scores'] = categorization_score(idx_train, y, idx_train, Y_train)
+        res.update({key: val.tolist() for key, val in md.items()})
+        return res
 
 _lsi_api_element_test_post_args = {
         # Warning this should be changed to wfields.DelimitedList

--- a/freediscovery/server/resources.py
+++ b/freediscovery/server/resources.py
@@ -218,7 +218,7 @@ class LsiApiElementPredict(Resource):
     def post(self, mid, **args):
         lsi = LSI(self._cache_dir, mid=mid)
         _, Y_train, Y_test, res  = lsi.predict(
-                accumulate='nearest-max', **args) 
+                method='nearest-max', **args) 
 
         idx_train = args['index']
         y = args['y']
@@ -249,7 +249,7 @@ class LsiApiElementTest(Resource):
         d_ref = parse_ground_truth_file(args["ground_truth_filename"])
         del args['ground_truth_filename']
         lsi_m, Y_train, Y_test, res  = lsi.predict(
-                accumulate='nearest-max', **args) 
+                method='nearest-max', **args) 
 
         idx_ref = lsi.fe.search(d_ref.index.values)
 

--- a/freediscovery/server/schemas.py
+++ b/freediscovery/server/schemas.py
@@ -73,10 +73,11 @@ class ClassificationScoresSchema(Schema):
 
 class LsiPredictSchema(ClassificationScoresSchema):
     prediction = fields.List(fields.Number(), required=True)
-    prediction_rel = fields.List(fields.Number(), required=True)
-    prediction_nrel = fields.List(fields.Number(), required=True)
-    nearest_rel_doc = fields.List(fields.Int(), required=True)
-    nearest_nrel_doc = fields.List(fields.Int(), required=True)
+    dist_p = fields.List(fields.Number(), required=True)
+    dist_n = fields.List(fields.Number())
+    ind_p = fields.List(fields.Int(), required=True)
+    ind_n = fields.List(fields.Int())
+    scores = fields.Nested(ClassificationScoresSchema(), required=True)
 
 
 class LsiParsSchema(Schema):

--- a/freediscovery/tests/test_integration.py
+++ b/freediscovery/tests/test_integration.py
@@ -82,12 +82,11 @@ def test_features_hashing(use_hashing, method):
         idx_gt = lsi.fe.search(ground_truth.index.values)
         idx_all = np.arange(lsi.fe.n_samples_, dtype='int')
 
-        for accumulate in ['nearest-max', 'centroid-max']:
-                            #'nearest-diff', 'nearest-combine', 'stacking']:
+        for method in ['nearest-neighbor-1', 'nearest-centroid']:
             _, Y_train, Y_pred, ND_train = lsi.predict(
                                     idx_gt,
                                     ground_truth.is_relevant.values,
-                                    accumulate=accumulate)
+                                    method=method)
             scores = categorization_score(idx_gt,
                                 ground_truth.is_relevant.values,
                                 idx_all, Y_pred)

--- a/freediscovery/tests/test_lsi.py
+++ b/freediscovery/tests/test_lsi.py
@@ -9,7 +9,7 @@ import numpy as np
 from numpy.testing import assert_allclose
 
 from freediscovery.text import FeatureVectorizer
-from freediscovery.lsi import LSI, TruncatedSVD_LSI
+from freediscovery.lsi import LSI, _TruncatedSVD_LSI
 from freediscovery.utils import categorization_score
 from freediscovery.io import parse_ground_truth_file
 from .run_suite import check_cache
@@ -21,6 +21,7 @@ def test_lsi():
     cache_dir = check_cache()
     data_dir = os.path.join(basename, "..", "data", "ds_001", "raw")
     n_features = 110000
+    n_components = 5
 
     fe = FeatureVectorizer(cache_dir=cache_dir)
     uuid = fe.preprocess(data_dir, file_pattern='.*\d.txt',
@@ -30,8 +31,9 @@ def test_lsi():
                         os.path.join(data_dir, "..", "ground_truth_file.txt"))
 
     lsi = LSI(cache_dir=cache_dir, dsid=uuid)
-    lsi_res, exp_var = lsi.transform(n_components=100)  # TODO unused variables
+    lsi_res, exp_var = lsi.transform(n_components=n_components)  # TODO unused variables
     lsi_id = lsi.mid
+    assert lsi_res.components_.shape == (n_components, n_features)
     assert lsi.get_dsid(fe.cache_dir, lsi_id) == uuid
     assert lsi.get_path(lsi_id) is not None
     assert lsi._load_pars(lsi_id) is not None
@@ -39,28 +41,43 @@ def test_lsi():
 
     idx_gt = lsi.fe.search(ground_truth.index.values)
     idx_all = np.arange(lsi.fe.n_samples_, dtype='int')
+    train_mask = [0, 1,  3, 4, 5]
 
     for method in ['nearest-neighbor-1', 'nearest-centroid']:
                         #'nearest-diff', 'nearest-combine', 'stacking']:
         _, Y_train, Y_pred, ND_train = lsi.predict(
-                                idx_gt,
-                                ground_truth.is_relevant.values,
+                                np.array(idx_gt)[train_mask],
+                                ground_truth.is_relevant.values[train_mask],
                                 method=method)
         scores = categorization_score(idx_gt,
                             ground_truth.is_relevant.values,
                             idx_all, Y_pred)
         assert_allclose(scores['precision'], 1, rtol=0.5)
-        assert_allclose(scores['recall'], 1, rtol=0.3)
+        assert_allclose(scores['recall'], 1, rtol=0.4)
 
 
     lsi.list_models()
     lsi.delete()
 
 
+def test_lsi_helper_class():
+    import scipy.sparse
+
+    X = scipy.sparse.rand(100, 10000)
+    lsi = _TruncatedSVD_LSI(n_components=20)
+    lsi.fit(X)
+    X_p = lsi.transform_lsi(X)
+    X_p2 = lsi.transform_lsi_norm(X)
+    assert lsi.components_.shape == (20, 10000)
+    assert X_p.shape == (100, 20)
+    assert X_p2.shape == (100, 20)
+
+
+
 def test_lsi_book_example():
     """ LSI example taken from the "Information retrieval" (2004) book by Grossman & Ophir
 
-    This illustrates the general principle of LSI using sklearn API with TruncatedSVD_LSI
+    This illustrates the general principle of LSI using sklearn API with _TruncatedSVD_LSI
     """
 
     # replacing "a" with "aa" as the former seems to be ignored by the CountVectorizer
@@ -82,7 +99,7 @@ def test_lsi_book_example():
     #print(X.todense().T)
     q = dm_vec.transform([querry])
 
-    lsi = TruncatedSVD_LSI(n_components=2)  #, algorithm='arpack')
+    lsi = _TruncatedSVD_LSI(n_components=2)  #, algorithm='arpack')
 
     lsi.fit(X)
     X_p = lsi.transform_lsi(X)

--- a/freediscovery/tests/test_lsi.py
+++ b/freediscovery/tests/test_lsi.py
@@ -40,7 +40,7 @@ def test_lsi():
     idx_gt = lsi.fe.search(ground_truth.index.values)
     idx_all = np.arange(lsi.fe.n_samples_, dtype='int')
 
-    for method in ['nearest-max', 'centroid-max']:
+    for method in ['nearest-neighbor-1', 'nearest-centroid']:
                         #'nearest-diff', 'nearest-combine', 'stacking']:
         _, Y_train, Y_pred, ND_train = lsi.predict(
                                 idx_gt,

--- a/freediscovery/tests/test_lsi.py
+++ b/freediscovery/tests/test_lsi.py
@@ -40,12 +40,12 @@ def test_lsi():
     idx_gt = lsi.fe.search(ground_truth.index.values)
     idx_all = np.arange(lsi.fe.n_samples_, dtype='int')
 
-    for accumulate in ['nearest-max', 'centroid-max']:
+    for method in ['nearest-max', 'centroid-max']:
                         #'nearest-diff', 'nearest-combine', 'stacking']:
         _, Y_train, Y_pred, ND_train = lsi.predict(
                                 idx_gt,
                                 ground_truth.is_relevant.values,
-                                accumulate=accumulate)
+                                method=method)
         scores = categorization_score(idx_gt,
                             ground_truth.is_relevant.values,
                             idx_all, Y_pred)

--- a/freediscovery/tests/test_server.py
+++ b/freediscovery/tests/test_server.py
@@ -302,10 +302,10 @@ def test_api_lsi(app):
 
     assert res.status_code == 200
     data = parse_res(res)
-    assert sorted(data.keys()) == sorted(['prediction',
-        'prediction_rel', 'prediction_nrel',
-        'nearest_rel_doc', 'nearest_nrel_doc',
-        'f1', 'recall', 'precision', 'roc_auc', 'average_precision'])
+    assert sorted(data.keys()) == sorted(['prediction', 'dist_p', 'dist_n',
+                                          'ind_p', 'ind_n', 'scores'])
+    assert sorted(data['scores'].keys()) == sorted(
+        ['f1', 'recall', 'precision', 'roc_auc', 'average_precision'])
 
     method = V01 + "/lsi/{}/test".format(lid)
     res = app.post(method,

--- a/freediscovery/tests/test_text.py
+++ b/freediscovery/tests/test_text.py
@@ -117,9 +117,11 @@ def test_df_filtering(use_hashing, min_df, max_df):
 def test_sampling_filenames():
     cache_dir = check_cache()
 
+    fe_pars = {'binary': True, 'norm': None, 'sublinear_tf': False}
+
     fe = FeatureVectorizer(cache_dir=cache_dir)
     uuid = fe.preprocess(data_dir, file_pattern='.*\d.txt',
-              use_hashing=True)  # TODO unused (overwritten on the next line)
+              use_hashing=True, **fe_pars)  # TODO unused (overwritten on the next line)
     uuid, filenames = fe.transform()
     fnames, X = fe.load(uuid)
 

--- a/freediscovery/text.py
+++ b/freediscovery/text.py
@@ -74,8 +74,8 @@ class FeatureVectorizer(_BaseTextTransformer):
                    'use_idf', 'sublinear_tf', 'binary', 'use_hashing']
     def preprocess(self, data_dir, file_pattern='.*', dir_pattern='.*',  n_features=11000000,
             chunk_size=5000, analyzer='word', ngram_range=(1, 1), stop_words='None',
-            n_jobs=1, use_idf=False, sublinear_tf=False, binary=True, use_hashing=True,
-            norm=None, min_df=0.0, max_df=1.0):
+            n_jobs=1, use_idf=False, sublinear_tf=True, binary=False, use_hashing=True,
+            norm='l2', min_df=0.0, max_df=1.0):
         """Initalize the features extraction. See sklearn.feature_extraction.text for a
         detailed description of the input parameters """
         data_dir = os.path.normpath(data_dir)


### PR DESCRIPTION
This is a significant refactoring of nearest-neighbor categorization with LSI, including

 - exposing a separate (and self consistent)  `freediscovery.categorization.NearestNeighborRanker` Python  class, following issue #48 
 - replacing the previously used custom `NearestCentroidClassifier`  by the standard version from scikit-learn
 - the `NearestNeighborRanker` can accept two types of input,
     * negative and positive labels in the training set => classical nearest-neighbor-1 classifier (supervised)
     * only positive labels => ranking based on the cosine distance (unsupervised)
  - also addressing issue #15

**Update:** also dropping support for scikit-learn 0.17 in this PR due to maintenance costs.