### PR TITLE
Add a NearestCentroid classification method

### DIFF
--- a/freediscovery/categorization.py
+++ b/freediscovery/categorization.py
@@ -60,6 +60,9 @@ class NearestCentroidRanker(NearestCentroid):
         -------
         C : array, shape = [n_samples]
         """
+        from sklearn.metrics.pairwise import pairwise_distances
+        from sklearn.utils.validation import check_array, check_is_fitted
+
         check_is_fitted(self, 'centroids_')
 
         X = check_array(X, accept_sparse='csr')

--- a/freediscovery/categorization.py
+++ b/freediscovery/categorization.py
@@ -10,7 +10,7 @@ import numpy as np
 import scipy
 from scipy.special import logit
 from sklearn.externals import joblib
-from sklearn.neighbors import NearestNeighbors
+from sklearn.neighbors import NearestNeighbors, NearestCentroid
 from sklearn.base import BaseEstimator
 from sklearn.utils.validation import check_array
 
@@ -42,6 +42,29 @@ def _unzip_relevant(idx_id, y):
     mask = np.asarray(y) > 0.5
     idx_id = np.asarray(idx_id, dtype='int')
     return idx_id[mask], idx_id[~mask]
+
+
+# a subclass of the NearestCentroid from scikit-learn that also
+# includes the distance to the nearest centroid
+
+class NearestCentroidRanker(NearestCentroid):
+
+    def decision_function(self, X):
+        """Compute the distances to the nearest centroid for
+        an array of test vectors X.
+
+        Parameters
+        ----------
+        X : array-like, shape = [n_samples, n_features]
+        Returns
+        -------
+        C : array, shape = [n_samples]
+        """
+        check_is_fitted(self, 'centroids_')
+
+        X = check_array(X, accept_sparse='csr')
+
+        return pairwise_distances(X, self.centroids_, metric=self.metric).min(axis=1)
 
 
 class NearestNeighborRanker(BaseEstimator, RankerMixin):

--- a/freediscovery/tests/test_categorize.py
+++ b/freediscovery/tests/test_categorize.py
@@ -47,7 +47,8 @@ ground_truth = parse_ground_truth_file(
                         os.path.join(data_dir, "..", "ground_truth_file.txt"))
 
 @pytest.mark.parametrize('method, cv', itertools.product(
-                       ["LinearSVC", "LogisticRegression", 'xgboost'],
+                       ["LinearSVC", "LogisticRegression", 'xgboost',
+                       'NearestNeighbor', 'NearestCentroid'],
                         #'MLPClassifier', 'ensemble-stacking' not supported in production the moment
                        [None, 'fast']))
 def test_categorization(method, cv):

--- a/freediscovery/tests/test_categorize.py
+++ b/freediscovery/tests/test_categorize.py
@@ -19,7 +19,8 @@ from sklearn.preprocessing import normalize
 
 from freediscovery.text import FeatureVectorizer
 from freediscovery.categorization import (Categorizer, _zip_relevant,
-        _unzip_relevant, NearestNeighborRanker)
+        _unzip_relevant, NearestNeighborRanker,
+        NearestCentroidRanker)
 from freediscovery.io import parse_ground_truth_file
 from freediscovery.utils import categorization_score
 from freediscovery.exceptions import OptionalDependencyMissing
@@ -47,8 +48,7 @@ ground_truth = parse_ground_truth_file(
                         os.path.join(data_dir, "..", "ground_truth_file.txt"))
 
 @pytest.mark.parametrize('method, cv', itertools.product(
-                       ["LinearSVC", "LogisticRegression", 'xgboost',
-                       'NearestNeighbor', 'NearestCentroid'],
+                       ["LinearSVC", "LogisticRegression", 'xgboost'],
                         #'MLPClassifier', 'ensemble-stacking' not supported in production the moment
                        [None, 'fast']))
 def test_categorization(method, cv):
@@ -223,3 +223,34 @@ def test_nearest_neighbor_ranker_unsupervised():
 
     assert_equal(y_pred, (1 - dist[:,0]/4))
 
+def test_nearest_centroid_ranker():
+    # in the case where there is a single point by centroid,
+    # nearest centroid should reduce to nearest neighbor
+    from sklearn.neighbors import NearestNeighbors
+    np.random.seed(0)
+
+    n_samples = 100
+    n_features = 120
+    X = np.random.rand(n_samples, n_features)
+    normalize(X, copy=False)
+    index = np.arange(n_samples, dtype='int')
+    y = np.arange(n_samples, dtype='int')
+    index_train, index_test, y_train, y_test = train_test_split(index, y)
+    X_train = X[index_train]
+    X_test = X[index_test]
+
+
+    nn = NearestNeighbors(n_neighbors=1)
+    nn.fit(X_train)
+    dist_ref, idx_ref = nn.kneighbors(X_test)
+
+    nc = NearestCentroidRanker()
+    nc.fit(X_train, y_train)
+    dist_pred = nc.decision_function(X_test)
+    y_pred = nc.predict(X_test)
+
+    # ensures that we have the same number of unique ouput points
+    # (even if absolute labels are not preserved)
+    assert np.unique(idx_ref[:,0]).shape ==  np.unique(y_pred).shape
+
+    assert_allclose(dist_pred, dist_ref[:,0])


### PR DESCRIPTION
scikit-learn has a `NearestCentroid` classification method (also known as  Rocchio classifier) however it cannot be used for ranking as the distance to the nearest centroid is not returned.

This PR subclasses this method in `freediscovery.categorization.NearestCentroidRanker` which can be used for categorization in the LSI space. This method was made standalone as part of the LSI refactoring step in PR #50 .