### PR TITLE
[WIP] Use original document_id the REST API for data ingestion and results

### DIFF
--- a/examples/python_categorization.py
+++ b/examples/python_categorization.py
@@ -42,7 +42,7 @@ if __name__ == '__main__':
     uuid = fe.preprocess(**fe_opts)
     uuid, filenames  = fe.transform()
 
-    seed_index = fe.search(seed_filenames)
+    seed_index = fe.db._search_filenames(seed_filenames)
 
     cat = _CategorizerWrapper(cache_dir=cache_dir, parent_id=uuid)
     cat.train(seed_index, seed_y)
@@ -50,7 +50,7 @@ if __name__ == '__main__':
     predictions, md = cat.predict()
 
     gt = parse_ground_truth_file( ground_truth_file)
-    idx_ref = cat.fe.search(gt.index.values)
+    idx_ref = cat.fe.db._search_filenames(gt.index.values)
     idx_res = np.arange(cat.fe.n_samples_, dtype='int')
 
     scores = categorization_score(idx_ref, gt.is_relevant.values,

--- a/freediscovery/categorization.py
+++ b/freediscovery/categorization.py
@@ -145,7 +145,7 @@ class NearestNeighborRanker(BaseEstimator, RankerMixin):
 
     def __init__(self, radius=1.0,
                  algorithm='brute', leaf_size=30, n_jobs=1,
-                 ranking='unsupervised', **kwargs):
+                 ranking='supervised', **kwargs):
 
         # define nearest neighbors search objects for positive and negative samples
         self._mod_p = NearestNeighbors(n_neighbors=1,

--- a/freediscovery/categorization.py
+++ b/freediscovery/categorization.py
@@ -182,10 +182,9 @@ class NearestNeighborRanker(BaseEstimator, RankerMixin):
            the ranking score in the range [-1, 1]
            For positive items score = 1 - cosine distance / 2
         """
-        # convert from eucledian distance in L2 norm space to cosine similarity
-        S_p = 1 - d_p/2
+        S_p = 1 - d_p
         if d_n is not None:
-            S_n = 1 - d_n/2
+            S_n = 1 - d_n
             return np.where(S_p > S_n,
                             S_p + 1,
                             -1 - S_n) / 2
@@ -245,7 +244,8 @@ class NearestNeighborRanker(BaseEstimator, RankerMixin):
                                            batch_size=batch_size)
 
         # only NearestNeighbor-1 (only one column in the kneighbors output)
-        D_p = D_p[:,0]
+        # convert from eucledian distance in L2 norm space to cosine similarity
+        D_p = D_p[:,0] / 2
         # map local index within _index_p, _index_n to global index
         ind_p = self._index_p[idx_p_loc[:,0]]
 
@@ -256,7 +256,7 @@ class NearestNeighborRanker(BaseEstimator, RankerMixin):
         if self._mod_n._fit_method is not None: # also corresponds to "unsupervised" method
             D_n, idx_n_loc = _chunk_kneighbors(self._mod_n.kneighbors, X,
                                                batch_size=batch_size)
-            D_n = D_n[:,0]
+            D_n = D_n[:,0] / 2
             ind_n = self._index_n[idx_n_loc[:,0]]
             md['ind_n'] = ind_n
             md['dist_n'] = D_n

--- a/freediscovery/ingestion.py
+++ b/freediscovery/ingestion.py
@@ -124,6 +124,15 @@ class DocumentIndex(object):
         return res
 
 
+    def _search_filenames(self, filenames):
+        """ A helper function that reproduces the previous behaviour in FeaturesVectorizer"""
+        #filenames_rel = [os.path.relpath(el, self.data_dir) for el in filenames]
+        query = pd.DataFrame(filenames, columns=['file_path'])
+
+        res = self.search(query)
+        return res.internal_id.values
+
+
     @classmethod
     def from_list(cls, metadata):
         """ Create a DocumentIndex from a list of dictionaries, for instance

--- a/freediscovery/ingestion.py
+++ b/freediscovery/ingestion.py
@@ -1,0 +1,61 @@
+# -*- coding: utf-8 -*-
+
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+from __future__ import unicode_literals
+
+import os.path
+import os
+from .exceptions import (DatasetNotFound, InitException, NotFound, WrongParameter)
+
+def _list_filenames(data_dir, dir_pattern=None, file_pattern=None):
+    """ List all files in a data_dir"""
+    import re
+    # parse all files in the folder
+    filenames = []
+    for root, subdirs, files in os.walk(data_dir):
+        if dir_pattern is None or re.match(dir_pattern, root):
+            for fname in files:
+                if file_pattern is None or re.match(file_pattern, fname):
+                    filenames.append(os.path.normpath(os.path.join(root, fname)))
+
+    # make sure that sorting order is deterministic
+    return sorted(filenames)
+
+def _prepare_data_ingestion(data_dir, metadata, file_pattern, dir_pattern):
+    """ Do some preprocessing of the input parameters
+    of FeatureVectorizer for data ingestion
+
+    Parmaters
+    ---------
+    data_dir : str
+        path to the data directory (used only if metadata not provided), default: None
+    metadata : list of dicts
+        a list of dictionaries with keys ['file_path', 'document_id', 'rendition_id']
+        describing the data ingestion (this overwrites data_dir)
+
+    Returns
+    -------
+    filenames : list
+      a list of filenames
+    metadata : a pandas.DataFrame
+      with at least keys 'filanames', optionally 'document_id' and 'rendition_id'
+    """
+
+    if data_dir is not None:
+        data_dir = os.path.normpath(data_dir)
+
+        if not os.path.exists(data_dir):
+            raise NotFound('data_dir={} does not exist'.format(data_dir))
+
+        filenames = _list_filenames(data_dir, dir_pattern, file_pattern)
+    else:
+        metadata = sorted(metadata, key=lambda x: x['file_path'])
+        filenames = [el['file_path'] for el in metadata]
+        data_dir = None
+
+        if not filenames: # no files were found
+            raise WrongParameter('No files to process were found!')
+
+    return data_dir, filenames, metadata

--- a/freediscovery/ingestion.py
+++ b/freediscovery/ingestion.py
@@ -133,6 +133,33 @@ class DocumentIndex(object):
         return res.internal_id.values
 
 
+    def render_dict(self, res):
+        """
+        Parameters
+        ----------
+        res : pandas.DataFrame
+            some dataset with additional data that must contain the 'internal_id' key
+
+        Results
+        -------
+        out : dict
+
+        """
+        res = res.set_index('internal_id')
+        db = self.data.set_index('internal_id')
+        base_keys = [key for key in self.data.columns if key != 'file_path']
+
+        out = []
+        for index, row in res.iterrows():
+            row_dict = row.to_dict()
+            db_sel = db.loc[index]
+            row_dict.update(db_sel[base_keys].to_dict())
+            row_dict['internal_id'] = index
+            out.append(row_dict)
+
+        return out
+
+
     @classmethod
     def from_list(cls, metadata):
         """ Create a DocumentIndex from a list of dictionaries, for instance

--- a/freediscovery/ingestion.py
+++ b/freediscovery/ingestion.py
@@ -7,6 +7,7 @@ from __future__ import unicode_literals
 
 import os.path
 import os
+import pandas as pd
 from .exceptions import (DatasetNotFound, InitException, NotFound, WrongParameter)
 
 def _list_filenames(data_dir, dir_pattern=None, file_pattern=None):
@@ -23,7 +24,7 @@ def _list_filenames(data_dir, dir_pattern=None, file_pattern=None):
     # make sure that sorting order is deterministic
     return sorted(filenames)
 
-def _prepare_data_ingestion(data_dir, metadata, file_pattern, dir_pattern):
+def _prepare_data_ingestion(data_dir, metadata, file_pattern=None, dir_pattern=None):
     """ Do some preprocessing of the input parameters
     of FeatureVectorizer for data ingestion
 
@@ -39,23 +40,45 @@ def _prepare_data_ingestion(data_dir, metadata, file_pattern, dir_pattern):
     -------
     filenames : list
       a list of filenames
-    metadata : a pandas.DataFrame
-      with at least keys 'filanames', optionally 'document_id' and 'rendition_id'
+    db : a pandas.DataFrame
+      with at least keys 'file_path', 'internal_id', optionally 'document_id' and 'rendition_id'
     """
 
-    if data_dir is not None:
+    if metadata is not None:
+        metadata = sorted(metadata, key=lambda x: x['file_path'])
+        filenames = [el['file_path'] for el in metadata]
+
+        data_dir = os.path.commonprefix(filenames)
+        data_dir = os.path.normpath(data_dir)
+
+        if not os.path.exists(data_dir) and os.path.exists(os.path.dirname(data_dir)):
+            data_dir = os.path.dirname(data_dir)
+        else:
+            raise IOError('data_dir={} does not exist!'.format(data_dir))
+
+        if not filenames: # no files were found
+            raise WrongParameter('No files to process were found!')
+        filenames_rel = [os.path.relpath(el, data_dir) for el in filenames]
+
+        # modify the metadata list inplace
+        for db_el, file_path in zip(metadata, filenames_rel):
+            db_el['file_path'] = file_path
+        db = pd.DataFrame(metadata)
+
+    elif data_dir is not None:
         data_dir = os.path.normpath(data_dir)
 
         if not os.path.exists(data_dir):
             raise NotFound('data_dir={} does not exist'.format(data_dir))
 
         filenames = _list_filenames(data_dir, dir_pattern, file_pattern)
+        filenames_rel = [os.path.relpath(el, data_dir) for el in filenames]
+        db = [{'file_path': file_path, 'internal_id': idx} \
+                            for idx, file_path in enumerate(filenames_rel)]
+
+        db = pd.DataFrame(db)
     else:
-        metadata = sorted(metadata, key=lambda x: x['file_path'])
-        filenames = [el['file_path'] for el in metadata]
-        data_dir = None
+        raise ValueError('At least one if data_dir, metadata must be provided')
 
-        if not filenames: # no files were found
-            raise WrongParameter('No files to process were found!')
 
-    return data_dir, filenames, metadata
+    return data_dir, filenames, db

--- a/freediscovery/parsers.py
+++ b/freediscovery/parsers.py
@@ -89,3 +89,24 @@ class EmailParser(_BaseTextTransformer):
 
         #pars['filenames_abs'] = [os.path.join(data_dir, el) for el in filenames_base]
         return dsid
+
+    def search(self, filenames):
+        """ Return the document ids that correspond to the provided filenames.
+
+        .. Warning: this function is deprecated as of 0.8, use DocumentIndex.search instead
+
+        Parameters
+        ----------
+        filenames : list[str]
+            list of filenames (relatives to the data_dir)
+
+        Returns
+        -------
+        indices : array[int]
+            corresponding list of document id (order is not preserved)
+        """
+        filenames_all = self._pars['filenames']
+        # calculate the indices of the intersection of filenames with filenames_all
+        ind_dict = dict((k,i) for i,k in enumerate(filenames_all))
+        indices = [ ind_dict[x] for x in filenames]
+        return np.array(indices)

--- a/freediscovery/parsers.py
+++ b/freediscovery/parsers.py
@@ -16,6 +16,7 @@ from sklearn.feature_extraction.text import TfidfTransformer, TfidfVectorizer
 from sklearn.preprocessing import normalize
 
 from .text import _BaseTextTransformer
+from .ingestion import _list_filenames
 from .utils import generate_uuid, _rename_main_thread
 from .exceptions import (DatasetNotFound, InitException, NotFound, WrongParameter)
 
@@ -50,7 +51,7 @@ class EmailParser(_BaseTextTransformer):
         self.data_dir = data_dir
 
         # parse all files in the folder
-        filenames = self._list_filenames(data_dir, dir_pattern, file_pattern)
+        filenames = _list_filenames(data_dir, dir_pattern, file_pattern)
 
         if not filenames: # no files were found
             raise WrongParameter('No files to process were found!')

--- a/freediscovery/search.py
+++ b/freediscovery/search.py
@@ -124,10 +124,10 @@ class Search(object):
 
         dist = pairwise_distances(q, self._fit_X,
                                   'euclidean',
-                                  n_jobs=self.n_jobs, squared=True)
+                                  n_jobs=self.n_jobs, squared=False)
         dist = dist[0]
 
-        # make sure the result positive and largest for best matches
-        scores = dist.max() - dist
+        # convert to a 2 - cosine_distance
+        scores = 2 - dist/2
 
         return scores

--- a/freediscovery/server/resources.py
+++ b/freediscovery/server/resources.py
@@ -131,7 +131,7 @@ class FeaturesApiElementIndex(Resource):
     @marshal_with(FeaturesElementIndexSchema())
     def get(self, dsid, **args):
         fe = FeatureVectorizer(self._cache_dir, dsid=dsid)
-        idx = fe.search(args['filenames'])
+        idx = fe.db._search_filenames(args['filenames'])
         return {'index': list(idx)}
 
 # ============================================================================ # 
@@ -301,7 +301,7 @@ class ModelsApiTest(Resource):
 
         y_res, md = cat.predict()
         d_ref = parse_ground_truth_file( args["ground_truth_filename"])
-        idx_ref = cat.fe.search(d_ref.index.values)
+        idx_ref = cat.fe.db._search_filenames(d_ref.index.values)
         idx_res = np.arange(cat.fe.n_samples_, dtype='int')
         res = categorization_score(idx_ref,
                                    d_ref.is_relevant.values,

--- a/freediscovery/server/resources.py
+++ b/freediscovery/server/resources.py
@@ -11,6 +11,7 @@ from flask_restful import abort, Resource
 from webargs import fields as wfields
 from flask_apispec import marshal_with, use_kwargs as use_args
 import numpy as np
+import pandas as pd
 from sklearn.metrics import precision_score, recall_score, f1_score, roc_auc_score, \
                             adjusted_rand_score, adjusted_mutual_info_score, v_measure_score
 import warnings
@@ -604,4 +605,9 @@ class SearchApi(Resource):
 
         query = args['query']
         scores = model.search(query)
-        return {'prediction': scores}
+        scores_pd = pd.DataFrame({'score': scores,
+                                  'internal_id': np.arange(model.fe.n_samples_, dtype='int')})
+
+        res = model.fe.db.render_dict(scores_pd)
+
+        return {'data': res}

--- a/freediscovery/server/schemas.py
+++ b/freediscovery/server/schemas.py
@@ -155,6 +155,13 @@ class MetricsDupDetectionSchema(Schema):
     f1_same_duplicates = fields.Number()
     mean_duplicates_count = fields.Number()
 
+class DocumentIndexSchema(Schema):
+    internal_id = fields.Int(required=True)
+    document_id = fields.Int()
+    render_id = fields.Int()
+
+class _SearchResponseSchemaElement(DocumentIndexSchema):
+    score = fields.Number(required=True)
 
 class SearchResponseSchema(Schema):
-    prediction = fields.List(fields.Number, required=True)
+    data = fields.Nested(_SearchResponseSchemaElement(), many=True, required=True)

--- a/freediscovery/server/schemas.py
+++ b/freediscovery/server/schemas.py
@@ -83,13 +83,21 @@ class LsiPostSchema(IDSchema):
 class CategorizationPostSchema(ClassificationScoresSchema):
     id = fields.Str(required=True)
 
+class DocumentIndexSchema(Schema):
+    internal_id = fields.Int(required=True)
+    document_id = fields.Int()
+    render_id = fields.Int()
+
+class _NNSchemaElement(DocumentIndexSchema):
+    distance = fields.Number(required=True)
+
+class _CategorizationPredictSchemaElement(DocumentIndexSchema):
+    score = fields.Number(required=True)
+    nn_positive = fields.Nested(_NNSchemaElement)
+    nn_negative = fields.Nested(_NNSchemaElement)
 
 class CategorizationPredictSchema(Schema):
-    prediction = fields.List(fields.Number, required=True)
-    dist_p = fields.List(fields.Number())
-    dist_n = fields.List(fields.Number())
-    ind_p = fields.List(fields.Int())
-    ind_n = fields.List(fields.Int())
+    data = fields.Nested(_CategorizationPredictSchemaElement(), many=True, required=True)
 
 
 class CategorizationParsSchema(Schema):
@@ -155,10 +163,6 @@ class MetricsDupDetectionSchema(Schema):
     f1_same_duplicates = fields.Number()
     mean_duplicates_count = fields.Number()
 
-class DocumentIndexSchema(Schema):
-    internal_id = fields.Int(required=True)
-    document_id = fields.Int()
-    render_id = fields.Int()
 
 class _SearchResponseSchemaElement(DocumentIndexSchema):
     score = fields.Number(required=True)

--- a/freediscovery/tests/test_categorize.py
+++ b/freediscovery/tests/test_categorize.py
@@ -79,7 +79,7 @@ def test_categorization(use_lsi, method, cv):
         uuid = lsi.mid
 
     cat = _CategorizerWrapper(cache_dir=cache_dir, parent_id=uuid, cv_n_folds=2)
-    index = cat.fe.search(ground_truth.index.values)
+    index = cat.fe.db._search_filenames(ground_truth.index.values)
 
     try:
         coefs, Y_train = cat.train(
@@ -94,7 +94,7 @@ def test_categorization(use_lsi, method, cv):
 
     Y_pred, md = cat.predict()
     X_pred = np.arange(cat.fe.n_samples_, dtype='int')
-    idx_gt = cat.fe.search(ground_truth.index.values)
+    idx_gt = cat.fe.db._search_filenames(ground_truth.index.values)
 
     scores = categorization_score(idx_gt,
                         ground_truth.is_relevant.values,
@@ -147,7 +147,7 @@ def test_pipeline(n_steps):
         raise ValueError
 
     cat = _CategorizerWrapper(cache_dir=cache_dir, parent_id=uuid, cv_n_folds=2)
-    index = cat.fe.search(ground_truth.index.values)
+    index = cat.fe.db._search_filenames(ground_truth.index.values)
 
     coefs, Y_train = cat.train( index, ground_truth.is_relevant.values)
 

--- a/freediscovery/tests/test_categorize.py
+++ b/freediscovery/tests/test_categorize.py
@@ -284,7 +284,7 @@ def test_nearest_neighbor_ranker_supervised(ranking):
         # make sure we get the same results as for the KNeighborsClassifier
         assert_equal(y_ref, y_train[idx])
     else:
-        assert_allclose(y_pred, 1 - md['dist_p']/4)
+        assert_allclose(y_pred, 1 - md['dist_p']/2)
         assert_array_equal(idx, md['ind_p'])
 
 def test_nearest_neighbor_ranker_unsupervised():

--- a/freediscovery/tests/test_ingestion.py
+++ b/freediscovery/tests/test_ingestion.py
@@ -1,0 +1,47 @@
+# -*- coding: utf-8 -*-
+
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+from __future__ import unicode_literals
+
+import os.path
+import numpy as np
+from numpy.testing import assert_equal, assert_array_equal
+import itertools
+import pytest
+
+from freediscovery.text import (FeatureVectorizer,
+                                _FeatureVectorizerSampled)
+from freediscovery.ingestion import _prepare_data_ingestion
+from .run_suite import check_cache
+
+basename = os.path.dirname(__file__)
+data_dir = os.path.join(basename, "..", "data", "ds_001", "raw")
+
+
+
+def test_ingestion_base_dir():
+    data_dir_res, filenames, md = _prepare_data_ingestion(data_dir, None, None, None)
+    assert data_dir_res == os.path.normpath(data_dir)
+    print(filenames)
+
+def test_ingestion_metadata():
+    fnames_in = ['0.7.47.101442.txt',
+          '0.7.47.117435.txt',
+          '0.7.6.28635.txt',
+          '0.7.6.28636.txt',
+          '0.7.6.28637.txt',
+          '0.7.6.28638.txt']
+
+    fnames_in = [os.path.join(data_dir, el) for el in fnames_in]
+
+    metadata = [ {'file_path': fname } for fname in fnames_in]
+
+    data_dir_res, filenames, md = _prepare_data_ingestion(data_dir, None, None, None)
+
+
+
+
+
+

--- a/freediscovery/tests/test_ingestion.py
+++ b/freediscovery/tests/test_ingestion.py
@@ -20,25 +20,30 @@ basename = os.path.dirname(__file__)
 data_dir = os.path.join(basename, "..", "data", "ds_001", "raw")
 
 
+fnames_in = ['0.7.47.101442.txt',
+             '0.7.47.117435.txt',
+             '0.7.6.28635.txt',
+             '0.7.6.28636.txt',
+             '0.7.6.28637.txt',
+             '0.7.6.28638.txt']
+fnames_in_abs = [os.path.join(data_dir, el) for el in fnames_in]
 
 def test_ingestion_base_dir():
-    data_dir_res, filenames, md = _prepare_data_ingestion(data_dir, None, None, None)
+    data_dir_res, filenames, db = _prepare_data_ingestion(data_dir, None)
     assert data_dir_res == os.path.normpath(data_dir)
-    print(filenames)
+    assert_array_equal(db.columns.values, ['file_path', 'internal_id'])
+    assert_array_equal(db.file_path.values, fnames_in)
+
 
 def test_ingestion_metadata():
-    fnames_in = ['0.7.47.101442.txt',
-          '0.7.47.117435.txt',
-          '0.7.6.28635.txt',
-          '0.7.6.28636.txt',
-          '0.7.6.28637.txt',
-          '0.7.6.28638.txt']
 
-    fnames_in = [os.path.join(data_dir, el) for el in fnames_in]
 
-    metadata = [ {'file_path': fname } for fname in fnames_in]
+    metadata = [ {'file_path': fname } for fname in fnames_in_abs]
 
-    data_dir_res, filenames, md = _prepare_data_ingestion(data_dir, None, None, None)
+    data_dir_res, filenames, md_table = _prepare_data_ingestion(None, metadata)
+
+    assert data_dir_res == os.path.normpath(data_dir)
+    assert filenames == fnames_in_abs
 
 
 

--- a/freediscovery/tests/test_ingestion.py
+++ b/freediscovery/tests/test_ingestion.py
@@ -13,11 +13,12 @@ import pytest
 
 from freediscovery.text import (FeatureVectorizer,
                                 _FeatureVectorizerSampled)
-from freediscovery.ingestion import _prepare_data_ingestion
+from freediscovery.ingestion import DocumentIndex
 from .run_suite import check_cache
 
 basename = os.path.dirname(__file__)
 data_dir = os.path.join(basename, "..", "data", "ds_001", "raw")
+cache_dir = check_cache()
 
 
 fnames_in = ['0.7.47.101442.txt',
@@ -29,24 +30,48 @@ fnames_in = ['0.7.47.101442.txt',
 fnames_in_abs = [os.path.join(data_dir, el) for el in fnames_in]
 
 def test_ingestion_base_dir():
-    data_dir_res, filenames, db = _prepare_data_ingestion(data_dir, None)
+    dbi = DocumentIndex.from_folder(data_dir)
+    data_dir_res, filenames, db = dbi.data_dir, dbi.filenames, dbi.data
     assert data_dir_res == os.path.normpath(data_dir)
     assert_array_equal(db.columns.values, ['file_path', 'internal_id'])
     assert_array_equal(db.file_path.values, fnames_in)
+    assert_array_equal([os.path.normpath(el) for el in  filenames],
+                       [os.path.join(data_dir_res, el) for el in db.file_path.values])
 
 
-def test_ingestion_metadata():
+def test_ingestion_pickling():
+    from sklearn.externals import joblib
+    db = DocumentIndex.from_folder(data_dir)
+    fname = os.path.join(cache_dir, 'document_index')
+    # check that db is picklable
+    joblib.dump(db, fname)
+    db2 = joblib.load(fname)
+    os.remove(fname)
 
 
-    metadata = [ {'file_path': fname } for fname in fnames_in_abs]
+@pytest.mark.parametrize('n_fields', [1, 2, 3])
+def test_ingestion_metadata(n_fields):
+    metadata = []
+    for idx, fname in enumerate(fnames_in_abs):
+        el = {'file_path': fname }
+        if n_fields >= 2:
+            el['document_id'] = 'a' + str(idx + 100)
+        if n_fields >= 3:
+            el['rendition_id'] = 1
+        metadata.append(el)
 
-    data_dir_res, filenames, md_table = _prepare_data_ingestion(None, metadata)
+    dbi = DocumentIndex.from_list(metadata)
+    data_dir_res, filenames, db = dbi.data_dir, dbi.filenames, dbi.data
 
     assert data_dir_res == os.path.normpath(data_dir)
     assert filenames == fnames_in_abs
+    if n_fields == 1:
+        columns_ref = sorted(['file_path', 'internal_id'])
+    elif n_fields == 2:
+        columns_ref = sorted(['file_path', 'document_id', 'internal_id'])
+    elif n_fields == 3:
+        columns_ref = sorted(['file_path', 'document_id', 'rendition_id', 'internal_id'])
 
-
-
-
-
-
+    assert_array_equal(sorted(db.columns.values), columns_ref)
+    assert_array_equal([os.path.normpath(el) for el in  filenames],
+                       [os.path.join(data_dir_res, el) for el in db.file_path.values])

--- a/freediscovery/tests/test_ingestion.py
+++ b/freediscovery/tests/test_ingestion.py
@@ -8,6 +8,7 @@ from __future__ import unicode_literals
 import os.path
 import numpy as np
 from numpy.testing import assert_equal, assert_array_equal
+from pandas.util.testing import assert_frame_equal
 import itertools
 import pytest
 import pandas as pd
@@ -72,6 +73,24 @@ def test_search_not_found():
     with pytest.raises(NotFound):
         sres = dbi.search(query)
 
+def test_ingestion_render_dict():
+    md = [{'file_path': '/test',  'document_id': 2},
+          {'file_path': '/test2', 'document_id': 1},
+          {'file_path': '/test3', 'document_id': 7},
+          {'file_path': '/test8', 'document_id': 9},
+          {'file_path': '/test9', 'document_id': 4},
+         ]
+
+    for idx, el in enumerate(md):
+        el['internal_id'] = idx
+
+    dbi = DocumentIndex.from_list(md)
+    res = pd.DataFrame([{'a': 2, 'internal_id': 3},
+                        {'a': 4, 'internal_id': 1}])
+    rd = dbi.render_dict(res)
+    assert_frame_equal(pd.DataFrame(rd),
+                       pd.DataFrame([{'a': 2, 'internal_id': 3, 'document_id': 9},
+                                     {'a': 4, 'internal_id': 1, 'document_id': 1}]))
 
 
 def test_search_document_id():

--- a/freediscovery/tests/test_integration.py
+++ b/freediscovery/tests/test_integration.py
@@ -62,7 +62,7 @@ def test_features_hashing(use_hashing, use_lsi, method):
             parent_id = uuid
             method = 'LogisticRegression'
         cat = _CategorizerWrapper(cache_dir=cache_dir, parent_id=parent_id, cv_n_folds=2)
-        index = cat.fe.search(ground_truth.index.values)
+        index = cat.fe.db._search_filenames(ground_truth.index.values)
 
         try:
             coefs, Y_train = cat.train(
@@ -75,7 +75,7 @@ def test_features_hashing(use_hashing, use_lsi, method):
 
         Y_pred, md = cat.predict()
         X_pred = np.arange(cat.fe.n_samples_, dtype='int')
-        idx_gt = cat.fe.search(ground_truth.index.values)
+        idx_gt = cat.fe.db._search_filenames(ground_truth.index.values)
 
         scores = categorization_score(idx_gt,
                             ground_truth.is_relevant.values,
@@ -85,7 +85,7 @@ def test_features_hashing(use_hashing, use_lsi, method):
         cat.delete()
     elif method == 'LSI':
 
-        idx_gt = lsi.fe.search(ground_truth.index.values)
+        idx_gt = lsi.fe.db._search_filenames(ground_truth.index.values)
         idx_all = np.arange(lsi.fe.n_samples_, dtype='int')
 
     elif method == 'DuplicateDetection':

--- a/freediscovery/tests/test_search.py
+++ b/freediscovery/tests/test_search.py
@@ -65,6 +65,9 @@ def test_search(kind):
         dist = s.search(query)
         assert dist.shape == (X.shape[0],)
         assert dist.argmax() == best_id
+        # 2 - cosine distance should be in [0, 2]
+        assert_array_less(dist, 2.001)
+        assert_array_less(0.001, dist)
 
 
 @pytest.mark.parametrize('kind,', ['regular', 'semantic'])

--- a/freediscovery/tests/test_server.py
+++ b/freediscovery/tests/test_server.py
@@ -348,10 +348,17 @@ def test_api_categorization(app, solver, cv):
     method = V01 + "/categorization/{}/predict".format(mid)
     res = app.get(method)
     data = parse_res(res)
+    assert sorted(data.keys()) == ['data']
+    assert len(data['data']) == len(y)
     if solver == 'NearestNeighbor':
-        assert sorted(data.keys()) == ['dist_n', 'dist_p', 'ind_n', 'ind_p', 'prediction']
+        for row in data['data']:
+            assert sorted(row.keys()) == sorted(['internal_id', 'score',
+                                                 'nn_positive', 'nn_negative'])
+            nn_p = row['nn_positive']
+            assert sorted(nn_p.keys()) == sorted(['internal_id', 'distance'])
     else:
-        assert sorted(data.keys()) == ['prediction']
+        for row in data['data']:
+            assert sorted(row.keys()) == sorted(['internal_id', 'score'])
 
     method = V01 + "/categorization/{}/test".format(mid)
     res = app.post(method,

--- a/freediscovery/tests/test_server.py
+++ b/freediscovery/tests/test_server.py
@@ -64,9 +64,7 @@ def app_notest():
 
 def get_features(app, hashed=True):
     method = V01 + "/feature-extraction/"
-    pars = dict(data_dir=data_dir, n_features=100000,
-                analyzer='word', stop_words='None',
-                ngram_range=[1, 1], use_hashing=hashed)
+    pars = dict(data_dir=data_dir, use_hashing=hashed)
     res = app.post(method, data=pars)
 
     assert res.status_code == 200, method
@@ -668,4 +666,7 @@ def test_api_clustering(app, method):
     res = app.get(method, data=dict(parent_id=parent_id, query="so that I can reserve a room"))
     assert res.status_code == 200
     data = parse_res(res)
-    assert sorted(data.keys()) == sorted(['prediction'])
+    assert sorted(data.keys()) == ['data']
+    for row in data['data']:
+        assert sorted(row.keys()) == sorted(['score', 'internal_id'])
+    print(data['data'])

--- a/freediscovery/tests/test_server.py
+++ b/freediscovery/tests/test_server.py
@@ -676,4 +676,3 @@ def test_api_clustering(app, method):
     assert sorted(data.keys()) == ['data']
     for row in data['data']:
         assert sorted(row.keys()) == sorted(['score', 'internal_id'])
-    print(data['data'])

--- a/freediscovery/tests/test_text.py
+++ b/freediscovery/tests/test_text.py
@@ -14,6 +14,7 @@ import pytest
 from freediscovery.text import (FeatureVectorizer,
                                 _FeatureVectorizerSampled)
 from .run_suite import check_cache
+from freediscovery.exceptions import (DatasetNotFound, InitException, NotFound, WrongParameter)
 
 basename = os.path.dirname(__file__)
 data_dir = os.path.join(basename, "..", "data", "ds_001", "raw")
@@ -104,19 +105,19 @@ def test_search_filenames(use_hashing):
 
     assert_equal(fe._pars['filenames'], filenames)
 
-
+    assert fe.db is not None
 
     for low, high, step in [(0, 1, 1),
                             (0, 4, 1),
                             (3, 1, -1)]:
         idx_slice = list(range(low, high, step))
         filenames_slice = [filenames[idx] for idx in idx_slice]
-        idx0 = fe.search(filenames_slice)
+        idx0 = fe.db._search_filenames(filenames_slice)
         assert_equal(idx0, idx_slice)
         assert_equal(filenames_slice, fe[idx0])
 
-    with pytest.raises(KeyError):
-        fe.search(['DOES_NOT_EXIST.txt'])
+    with pytest.raises(NotFound):
+        fe.db._search_filenames(['DOES_NOT_EXIST.txt'])
 
     if not use_hashing:
         n_top_words = 5

--- a/freediscovery/text.py
+++ b/freediscovery/text.py
@@ -17,7 +17,7 @@ from sklearn.pipeline import make_pipeline
 
 from .pipeline import PipelineFinder
 from .utils import generate_uuid, _rename_main_thread
-from .ingestion import _list_filenames, _prepare_data_ingestion
+from .ingestion import DocumentIndex
 from .exceptions import (DatasetNotFound, InitException, NotFound, WrongParameter)
 
 
@@ -275,7 +275,11 @@ class FeatureVectorizer(_BaseTextTransformer):
 
         """
 
-        data_dir, filenames, metadata = _prepare_data_ingestion(data_dir, metadata, file_pattern, dir_pattern)
+        if metadata is not None:
+            db = DocumentIndex.from_list(metadata)
+        elif data_dir is not None:
+            db = DocumentIndex.from_folder(data_dir, file_pattern, dir_pattern)
+        data_dir, filenames, db = db.data_dir, db.filenames, db.data
 
         self.data_dir = data_dir
         if analyzer not in ['word', 'char', 'char_wb']:
@@ -290,7 +294,7 @@ class FeatureVectorizer(_BaseTextTransformer):
         if n_features is None and use_hashing:
             n_features = 100001 # default size of the hashing table
 
-        filenames_rel = [os.path.relpath(el, data_dir) for el in filenames]
+        filenames_rel = db.file_path.values.tolist()
         self.dsid = dsid = generate_uuid()
         self.dsid_dir = dsid_dir = os.path.join(self.cache_dir, dsid)
 

--- a/freediscovery/text.py
+++ b/freediscovery/text.py
@@ -142,6 +142,8 @@ class _BaseTextTransformer(object):
     def search(self, filenames):
         """ Return the document ids that correspond to the provided filenames.
 
+        .. Warning: this function is deprecated as of 0.8, use DocumentIndex.search instead
+
         Parameters
         ----------
         filenames : list[str]


### PR DESCRIPTION
Currently FreeDiscovery can ingest documents in a folder specified  by `data_dir` parameter in the  `feature-extraction/` endpoint, then a unique `internal_id` is associated to each document, and all estimators estimators (e.g. categorization, clustering etc) take as input data specified by `internal_id` and return results as a function of `document_id`. 

This PR (work in progress) aims to add the ability to ingest documents specified by a list of dictionaries containing the file path of each file as well as the external `document_id` of each document (along with an optional `rendition_id`). The results of e.g. categorization could then also be returned, with the `original_id` (and `rendition_id`) specified.

This implementation thus adds a mapping layer between the `internal_id` used by the code and the `original_id` / `rendition_id` provided or returned by the REST API.

This is sill work in progress.