### PR TITLE
Make sure that query_features uses english stop words

### DIFF
--- a/freediscovery/cluster/base.py
+++ b/freediscovery/cluster/base.py
@@ -27,6 +27,7 @@ def select_top_words(word_list, n=10):
     """ Filter out cluster term names"""
     import re
     from nltk.stem.porter import PorterStemmer
+    from sklearn.feature_extraction.stop_words import ENGLISH_STOP_WORDS
     st = PorterStemmer()
     out_st = []
     out = []
@@ -37,6 +38,7 @@ def select_top_words(word_list, n=10):
                 re.match('[^a-zA-Z0-9]', word_st) or\
                         word in COMMON_FIRST_NAMES or \
                         word in CUSTOM_STOP_WORDS or\
+                        word in ENGLISH_STOP_WORDS or \
                         word_st in out_st: # ignore stemming duplicate
             continue
         out_st.append(word_st)

--- a/freediscovery/text.py
+++ b/freediscovery/text.py
@@ -401,23 +401,6 @@ class FeatureVectorizer(_BaseTextTransformer):
         _touch(os.path.join(dsid_dir, 'processing_finished'))
         return dsid, filenames_base
 
-    def query_features(self, indices, n_top_words=10):
-        """ Query the features with most weight"""
-
-        # this should raise a warning when used with wrong weights
-        X = joblib.load(os.path.join(self.dsid_dir, 'features'))
-        X = X[indices]
-
-        centroid = X.sum(axis=0).view(type=np.ndarray)[0] / len(indices)
-        order_centroid = centroid.argsort()[::-1]
-        terms = self.vect.get_feature_names()
-
-        out = []
-        for ridx, idx in enumerate(order_centroid):
-            if ridx >= n_top_words:
-                break
-            out.append(terms[idx])
-        return out
 
     @property
     def n_features_(self):
@@ -433,6 +416,23 @@ class FeatureVectorizer(_BaseTextTransformer):
             return vect.named_steps['hashingvectorizer'].get_params()['n_features']
         else:
             raise ValueError
+
+    def query_features(self, indices, n_top_words=10, remove_stop_words=False):
+        """ Query the features with most weight
+
+        Parameters
+        ----------
+        indices : list or ndarray
+          indices for the subcluster
+        n_top_words : int
+          the number of workds to return
+        remove_stop_words : bool
+          remove stop words
+        """
+        from .utils import _query_features
+
+        X = joblib.load(os.path.join(self.dsid_dir, 'features'))
+        return _query_features(self.vect, X, indices, n_top_words, remove_stop_words)
 
 
     def _aggregate_features(self):

--- a/freediscovery/utils.py
+++ b/freediscovery/utils.py
@@ -122,3 +122,39 @@ def setup_model(base_path):
         os.remove(mid_dir)  # removing the old folder nevertheless
     os.mkdir(mid_dir)
     return mid, mid_dir
+
+
+def _query_features(vect, X, indices, n_top_words=10, remove_stop_words=False):
+    """ Query the features with most weight
+
+    Parameters
+    ----------
+    vect : TfidfVectorizer
+       the vectorizer object
+    X : ndarray
+       the document term tfidf array
+    indices : list or ndarray
+      indices for the subcluster
+    n_top_words : int
+      the number of workds to return
+    remove_stop_words : bool
+      remove stop words
+    """
+    from .cluster.base import select_top_words
+
+    # this should raise a warning when used with wrong weights
+    X = X[indices]
+
+    centroid = X.sum(axis=0).view(type=np.ndarray)[0] / len(indices)
+    order_centroid = centroid.argsort()[::-1]
+    terms = vect.get_feature_names()
+
+    out = []
+    for ridx, idx in enumerate(order_centroid):
+        if len(out) >= n_top_words:
+            break
+        if remove_stop_words:
+            out += select_top_words([terms[idx]])
+        else:
+            out.append(terms[idx])
+    return out


### PR DESCRIPTION
This PR includes a small refactoring of the `query_features` that allows to return the features used in a given document, and ensures that when returning top words characterizing a cluster, English stop words are removed.