### PR TITLE
FIX Explain categorization results with LogisticRegression

### DIFF
--- a/freediscovery/categorization.py
+++ b/freediscovery/categorization.py
@@ -44,6 +44,46 @@ def _unzip_relevant(idx_id, y):
     return idx_id[mask], idx_id[~mask]
 
 
+def explain_binary_categorization(estimator, vocabulary, X_row):
+    """Explain the binary categorization results
+
+    Parameters
+    ----------
+    estimator : sklearn.base.BaseEstimator
+      the binary categorization estimator
+      (must have a `decision_function` method)
+    vocabulary : list [n_features]
+      vocabulary (list of words or n-grams) 
+    X_row : sparse CSR ndarray [n_features]
+      a row of the document term matrix
+    """
+    if X_row.ndim != 2 or X_row.shape[0] != 1:
+        raise ValueError('X_row must be an 2D sparse array,'
+                         'with shape (1, N) not {}'.format(X_row.shape))
+    if X_row.shape[1] != len(vocabulary):
+        raise ValueError(
+                'The vocabulary length ({}) does not match '.format(len(vocabulary)) +\
+                'the number of features in X_row ({})'.format(X_row.shape[1]))
+
+    vocabulary_inv = {ind: key for key, ind in vocabulary.items()}
+
+
+    if type(estimator).__name__ == 'LogisticRegression':
+        coef_ = estimator.coef_
+        if X_row.shape[1] != coef_.shape[1]:
+            raise ValueError("Coefficients size {} does not match n_features={}".format(
+                                        coef_.shape[1], X_row.shape[1]))
+
+        indices = X_row.indices
+        weights = X_row.data*estimator.coef_[0, indices]
+        weights_dict = {}
+        for ind, value in zip(indices, weights):
+            key = vocabulary_inv[ind]
+            weights_dict[key] = value
+        return weights_dict
+    else:
+        raise NotImplementedError()
+
 # a subclass of the NearestCentroid from scikit-learn that also
 # includes the distance to the nearest centroid
 

--- a/freediscovery/tests/test_categorize.py
+++ b/freediscovery/tests/test_categorize.py
@@ -116,6 +116,23 @@ def test_categorization(use_lsi, method, cv):
     assert_allclose(scores['recall'], 1, rtol=0.68)
     cat.delete()
 
+def test_explain_categorization():
+    from freediscovery.categorization import explain_binary_categorization
+
+    uuid = vect_uuid
+
+    cat = _CategorizerWrapper(cache_dir=cache_dir, parent_id=uuid, cv_n_folds=2)
+    index = cat.fe.db._search_filenames(ground_truth.file_path.values)
+
+    model, _ = cat.train(index,
+                         ground_truth.is_relevant.values,
+                         method='LogisticRegression')
+    _, X = cat.fe.load()
+    vect = cat.fe._load_model()
+
+    weights = explain_binary_categorization(model, vect.vocabulary_, X[0, :])
+    assert len(weights.keys()) < len(vect.vocabulary_) # not all vocabulary keys are returned
+
 
 @pytest.mark.parametrize('batch_size', [1, 101, 100])
 def test_nn_chunking(batch_size):


### PR DESCRIPTION
This PR addresses the first step of issue #33 on computing the feature weights in the case of LogisticRegression in order the explain the categorization results.  The second step of the parent issue is being addressed by @DenisFLASH in PR #74 .