### PR TITLE
REST API improvements

### DIFF
--- a/build_tools/requirements_pip.txt
+++ b/build_tools/requirements_pip.txt
@@ -1,4 +1,3 @@
-flask-restful==0.3.5
 marshmallow==2.12.1
 webargs==1.5.2
 flask_apispec

--- a/doc/rest_api/index.rst
+++ b/doc/rest_api/index.rst
@@ -3,6 +3,13 @@ REST API Reference
 
 This REST API allows to use FreeDiscovery from any supported programming language. 
 
+A manually updated REST API specification listed below. 
+
+FreeDiscovery also generates,
+  * an OpenAPI / Swagger API specification accessible at `/swagger/`
+  * a Swagger User interface from the generated specification at `/swagger-ui/`
+(though the generation of REST API documentation is still experimental).
+
 
 Load Benchmark Dataset
 ----------------------

--- a/freediscovery/server/resources.py
+++ b/freediscovery/server/resources.py
@@ -7,9 +7,10 @@ from __future__ import print_function
 import os
 from glob import glob
 
-from flask_restful import abort, Resource
+#from flask_restful import Resource
 from webargs import fields as wfields
-from flask_apispec import marshal_with, use_kwargs as use_args
+from flask_apispec import (marshal_with, use_kwargs as use_args,
+                           MethodResource as Resource)
 import numpy as np
 import pandas as pd
 from sklearn.metrics import precision_score, recall_score, f1_score, roc_auc_score, \
@@ -51,6 +52,8 @@ from .schemas import (IDSchema, FeaturesParsSchema,
                       )
 
 EPSILON = 1e-3 # small numeric value
+
+
 
 # ============================================================================ # 
 #                         Datasets download                                    #

--- a/freediscovery/tests/test_server.py
+++ b/freediscovery/tests/test_server.py
@@ -724,7 +724,7 @@ def test_dupdetection_metrics_get(app, metrics):
 
 
 @pytest.mark.parametrize("method", ['regular', 'semantic'])
-def test_api_clustering(app, method):
+def test_api_search(app, method):
 
     if method == 'regular':
         dsid, lsi_id, _ = get_features_lsi(app, hashed=False)


### PR DESCRIPTION
This PR,
 * removes the `flask_restfull` dependency (issue #7 )
 * allows to generate an automatic REST API documentation (step 1 of issue #79  ) except for all endpoints except two (categorization and threading POST)
 * as a side effect this appears to fix issue  https://github.com/FreeDiscovery/FreeDiscovery/issues/31 on exception handling though this would need additional verification.

@dmytrobondarchuk would you be able to review this PR?