### PR TITLE
Multiclass categorization

### DIFF
--- a/doc/whats_new.md
+++ b/doc/whats_new.md
@@ -9,9 +9,11 @@
 
 
 ### Enhancements
+ * Support for multi-class categorization (PR [#96](https://github.com/FreeDiscovery/FreeDiscovery/pull/96/files)) 
 
  * The REST API documentation is generated automatically from the code (using an OpenAPI specification) which allows to enforce consistency between the code and the docs (PR [#85](https://github.com/FreeDiscovery/FreeDiscovery/pull/85))
  
+
 
 ### API Changes
  
@@ -22,6 +24,7 @@
     - `/api/v0/feature-extraction/{dsid}/id-mapping/flat`
     - `/api/v0/feature-extraction/{dsid}/id-mapping/nested`
     - `/api/v0/email-parser/{dsid}/index`
+  * Significant changes in the REST API to accomodate for multi-class categorization 
 
 
 ## Version 0.8

--- a/examples/REST_categorization.py
+++ b/examples/REST_categorization.py
@@ -116,7 +116,7 @@ if __name__ == '__main__':
     print("\n3.a. Train the categorization model")
     print("   {} relevant, {} non-relevant files".format(seed_y.count(1), seed_y.count(0)))
 
-    seed_index_nested = [{'document_id': internal_id, 'y': y} \
+    seed_index_nested = [{'document_id': internal_id, 'category': y} \
                                 for internal_id, y in zip(seed_document_id, seed_y)]
 
     for method, use_lsi in [('LinearSVC', False),
@@ -137,7 +137,7 @@ if __name__ == '__main__':
 
         res = requests.post(url,
                             json={'parent_id': parent_id,
-                                  'index_nested': seed_index_nested,
+                                  'data': seed_index_nested,
                                   'method': method,  # one of "LinearSVC", "LogisticRegression", 'xgboost'
                                   }).json()
 
@@ -151,7 +151,7 @@ if __name__ == '__main__':
         res = requests.get(url).json()
 
         print('\n'.join(['     - {}: {}'.format(key, val) for key, val in res.items() \
-                                                          if key not in ['index', 'y']]))
+                                                          if key not in ['index', 'category']]))
 
         print("\n3.c Categorize the complete dataset with this model")
         url = BASE_URL + '/categorization/{}/predict'.format(mid)
@@ -159,20 +159,7 @@ if __name__ == '__main__':
         res = requests.get(url).json()
 
         if method == "NearestNeighbor":
-
-            def flatten_dict(d, parent_key='', sep='__'):
-                """Flatten a nested dictionary """
-                import collections
-                items = []
-                for k, v in d.items():
-                    new_key = parent_key + sep + k if parent_key else k
-                    if isinstance(v, collections.MutableMapping):
-                        items.extend(flatten_dict(v, new_key, sep=sep).items())
-                    else:
-                        items.append((new_key, v))
-                return dict(items)
-            
-            data = [flatten_dict(el) for el in res['data']]
+            data = res['data']
         else:
             data = res['data']
 
@@ -183,18 +170,15 @@ if __name__ == '__main__':
 
         print(df)
 
-        print("\n3.d Compute the categorization scores")
-        url = BASE_URL + '/metrics/categorization'
-        print(" GET", url)
-        res = requests.post(url, json={'y_true': ground_truth_y,
-                                      'y_pred': df.score.values.tolist(),
-                                     } ).json()
+        #print("\n3.d Compute the categorization scores")
+        #url = BASE_URL + '/metrics/categorization'
+        #print(" GET", url)
+        #res = requests.post(url, json={'y_true': ground_truth_y,
+        #                              'y_pred': df.score.values.tolist(),
+        #                             } ).json()
 
 
-
-
-
-        print('    => Test scores: MAP = {average_precision:.3f}, ROC-AUC = {roc_auc:.3f}'.format(**res))
+        #print('    => Test scores: MAP = {average_precision:.3f}, ROC-AUC = {roc_auc:.3f}'.format(**res))
 
     # 4. Cleaning
     print("\n5.a Delete the extracted features (and LSI decomposition)")

--- a/examples/REST_categorization.py
+++ b/examples/REST_categorization.py
@@ -164,9 +164,9 @@ if __name__ == '__main__':
             data = res['data']
 
         df = pd.DataFrame(data).set_index('internal_id')
-        if method == "NearestNeighbor":
-            df = df[['document_id', 'nn_negative__distance', 'nn_negative__document_id',
-                  'nn_positive__distance', 'nn_positive__document_id', 'score']]
+        #if method == "NearestNeighbor":
+        #    df = df[['document_id', 'nn_negative__distance', 'nn_negative__document_id',
+        #          'nn_positive__distance', 'nn_positive__document_id', 'score']]
 
         print(df)
 

--- a/freediscovery/categorization.py
+++ b/freediscovery/categorization.py
@@ -10,39 +10,15 @@ import numpy as np
 import scipy
 from scipy.special import logit
 from sklearn.externals import joblib
-from sklearn.neighbors import NearestNeighbors, NearestCentroid
-from sklearn.base import BaseEstimator
-from sklearn.utils.validation import check_array
 from sklearn.preprocessing import LabelEncoder
 
 
-from .base import _BaseWrapper, RankerMixin
+from .base import _BaseWrapper
 from .utils import setup_model, _rename_main_thread
+from .neighbors import NearestCentroidRanker, NearestNeighborRanker
 from .exceptions import (ModelNotFound, WrongParameter, NotImplementedFD, OptionalDependencyMissing)
 
 
-def _zip_relevant(relevant_id, non_relevant_id):
-    """ Take a list of relevant and non relevant documents id and return
-    an array of indices and prediction values """
-    idx_id = np.hstack((np.asarray(relevant_id), np.asarray(non_relevant_id)))
-    y = np.concatenate((np.ones((len(relevant_id))),
-                        np.zeros((len(non_relevant_id))))).astype(np.int)
-    return idx_id, y
-
-def _unzip_relevant(idx_id, y):
-    """Take an array of indices and prediction values and return
-    a list of relevant and non relevant documents id
-
-    Parameters
-    ----------
-    idx_id : ndarray[int] (n_samples)
-        array of indices
-    y : ndarray[float] (n_samples)
-        target array
-    """
-    mask = np.asarray(y) > 0.5
-    idx_id = np.asarray(idx_id, dtype='int')
-    return idx_id[mask], idx_id[~mask]
 
 
 def explain_binary_categorization(estimator, vocabulary, X_row):
@@ -85,239 +61,6 @@ def explain_binary_categorization(estimator, vocabulary, X_row):
     else:
         raise NotImplementedError()
 
-# a subclass of the NearestCentroid from scikit-learn that also
-# includes the distance to the nearest centroid
-
-class NearestCentroidRanker(NearestCentroid):
-
-    def decision_function(self, X):
-        """Compute the distances to the nearest centroid for
-        an array of test vectors X.
-
-        Parameters
-        ----------
-        X : array-like, shape = [n_samples, n_features]
-        Returns
-        -------
-        C : array, shape = [n_samples]
-        """
-        from sklearn.metrics.pairwise import pairwise_distances
-        from sklearn.utils.validation import check_array, check_is_fitted
-
-        check_is_fitted(self, 'centroids_')
-
-        X = check_array(X, accept_sparse='csr')
-
-        return pairwise_distances(X, self.centroids_, metric=self.metric).min(axis=1)
-
-def _chunk_kneighbors(func, X, batch_size=5000, **args):
-    """ Chunk kneighbors computations to reduce RAM requirements
-
-    Parameters
-    ----------
-    func : function
-      the function to run
-    X : ndarray
-      the array func is applied to
-    batch_size : int
-      batch size
-
-    Returns
-    -------
-    dist : array
-       distance array
-    ind : array of indices
-    """
-    n_samples = X.shape[0]
-    ind_arr = []
-    dist_arr = []
-    # don't enter the last loop if n_sampes is a multiple of batch_size
-    for k in range(n_samples//batch_size + int(n_samples % batch_size != 0)):
-        mslice = slice(k*batch_size, min((k+1)*batch_size, n_samples))
-        X_sl = X[mslice, :]
-        dist_k, ind_k = func(X_sl, **args)
-        ind_arr.append(ind_k)
-        dist_arr.append(dist_k)
-    return (np.concatenate(dist_arr, axis=0),
-            np.concatenate(ind_arr, axis=0))
-
-
-
-class NearestNeighborRanker(BaseEstimator, RankerMixin):
-    """A nearest neighbor ranker, behaves like
-        * KNeigborsClassifier (supervised) when trained on both positive and negative samples
-        * NearestNeighbors  (unsupervised) when trained on positive samples only
-
-    Parameters
-    ----------
-    radius : float, optional (default = 1.0)
-        Range of parameter space to use by default for :meth:`radius_neighbors`
-        queries.
-
-    algorithm : {'auto', 'ball_tree', 'kd_tree', 'brute'}, optional
-        Algorithm used to compute the nearest neighbors:
-
-        - 'ball_tree' will use :class:`BallTree`
-        - 'kd_tree' will use :class:`KDtree`
-        - 'brute' will use a brute-force search.
-        - 'auto' will attempt to decide the most appropriate algorithm
-          based on the values passed to :meth:`fit` method.
-
-        Note: fitting on sparse input will override the setting of
-        this parameter, using brute force.
-
-    leaf_size : int, optional (default = 30)
-        Leaf size passed to BallTree or KDTree.  This can affect the
-        speed of the construction and query, as well as the memory
-        required to store the tree.  The optimal value depends on the
-        nature of the problem.
-
-    n_jobs : int, optional (default = 1)
-        The number of parallel jobs to run for neighbors search.
-        If ``-1``, then the number of jobs is set to the number of CPU cores.
-
-    method : str, def
-        If "unsupervised" only distances to the positive samples are used in the ranking
-        If "supervised" both the distance to the positive and negative documents are used
-        for ranking (i.e. if a document is slightly further away from a positive document
-        than from a negative one, it will be considered negative with a very low score)
-
-    """
-
-    def __init__(self, radius=1.0,
-                 algorithm='brute', leaf_size=30, n_jobs=1,
-                 ranking='supervised', **kwargs):
-
-        # define nearest neighbors search objects for positive and negative samples
-        self._mod_p = NearestNeighbors(n_neighbors=1,
-                                       leaf_size=leaf_size,
-                                       algorithm=algorithm,
-                                       n_jobs=n_jobs,
-                                       metric='euclidean',  # euclidean metric by default
-                                       **kwargs)
-        self._mod_n = NearestNeighbors(n_neighbors=1,
-                                       leaf_size=leaf_size,
-                                       algorithm=algorithm,
-                                       n_jobs=n_jobs,
-                                       metric='euclidean',  # euclidean metric by default
-                                       **kwargs)
-        if ranking not in ['supervised', 'unsupervised']:
-            raise ValueError
-        self.ranking_ = ranking
-
-    @staticmethod
-    def _ranking_score(d_p, d_n=None):
-        """ Compute the ranking score from the positive an negative
-        distances on L2 normalized data
-
-        Parameters
-        ----------
-        d_p : array (n_samples,)
-           distance to the positive samples
-        d_n : array (n_samples,)
-           (optional) distance to the negative samples
-
-        Returns
-        -------
-        score : array (n_samples,)
-           the ranking score in the range [-1, 1]
-           For positive items score = 1 - cosine distance / 2
-        """
-        S_p = 1 - d_p
-        if d_n is not None:
-            S_n = 1 - d_n
-            return np.where(S_p > S_n,
-                            S_p + 1,
-                            -1 - S_n) / 2
-        else:
-            return (S_p + 1) / 2
-
-    def fit(self, X, y):
-        """Fit the model using X as training data
-        Parameters
-        ----------
-        X : {array-like, sparse matrix, BallTree, KDTree}
-            Training data, shape [n_samples, n_features],
-
-        """
-        X = check_array(X, accept_sparse='csr')
-
-        index = np.arange(X.shape[0], dtype='int')
-
-        self._index_p, self._index_n = _unzip_relevant(index, y)
-
-
-        if self._index_p.shape[0] > 0:
-            self._mod_p.fit(X[self._index_p])
-        else:
-            raise ValueError('Training sets with no positive labels are not supported!')
-        if self._index_n.shape[0] > 0:
-            self._mod_n.fit(X[self._index_n])
-        else:
-            pass
-
-    def kneighbors(self, X=None, batch_size=5000):
-        """Finds the K-neighbors of a point.
-        Returns indices of and distances to the neighbors of each point.
-        Parameters
-        ----------
-        X : array-like, shape (n_samples, n_features)
-            the input array
-        batch_size : int
-            the batch size
-        Returns
-        -------
-        score : array
-            ranking score (based on cosine similarity)
-        ind : array
-            Indices of the nearest points in the population matrix.
-        md : dict
-            Additional result data
-              * ind_p : Indices of the nearest positive points
-              * ind_n : Indices of the nearest negate points
-              * dist_p : distance to the nearest positive points
-              * dist_n : distance to the nearest negate points
-        --------
-        """
-        X = check_array(X, accept_sparse='csr')
-
-        D_p, idx_p_loc = _chunk_kneighbors(self._mod_p.kneighbors, X,
-                                           batch_size=batch_size)
-
-        # only NearestNeighbor-1 (only one column in the kneighbors output)
-        # convert from eucledian distance in L2 norm space to cosine similarity
-        D_p = D_p[:,0] / 2
-        # map local index within _index_p, _index_n to global index
-        ind_p = self._index_p[idx_p_loc[:,0]]
-
-        md = {'dist_p': D_p,
-              'ind_p': ind_p,
-             }
-
-        if self._mod_n._fit_method is not None: # also corresponds to "unsupervised" method
-            D_n, idx_n_loc = _chunk_kneighbors(self._mod_n.kneighbors, X,
-                                               batch_size=batch_size)
-            D_n = D_n[:,0] / 2
-            ind_n = self._index_n[idx_n_loc[:,0]]
-            md['ind_n'] = ind_n
-            md['dist_n'] = D_n
-            if self.ranking_ == 'supervised':
-                ind = np.where(D_p <= D_n, ind_p, ind_n)
-            else:
-                ind = ind_p
-        else:
-            D_n = None
-            ind = ind_p
-
-        if self.ranking_ == 'supervised':
-            score = self._ranking_score(D_p, D_n)
-        elif self.ranking_ == 'unsupervised':
-            score = self._ranking_score(D_p, None)
-        else:
-            raise ValueError
-
-
-        return score, ind , md
 
 
 
@@ -511,7 +254,7 @@ class _CategorizerWrapper(_BaseWrapper):
 
         md = {}
         if isinstance(cmod, NearestNeighborRanker):
-            res, _, md = cmod.kneighbors(ds)
+            res, md = cmod.kneighbors(ds)
         elif hasattr(cmod, 'decision_function'):
             res = cmod.decision_function(ds)
         else:  # gradient boosting define the decision function by analogy

--- a/freediscovery/metrics.py
+++ b/freediscovery/metrics.py
@@ -69,5 +69,14 @@ def mean_duplicates_count_score(x, y):
     return np.mean(score)
 
 
+def seuclidean_dist2cosine_sim(x):
+    """Given an squared euclidean distance on L2 normalized data,
+    convert it to the cosine similarity
+
+    Warning: this function would give completely wrong results if,
+      * the euclidean distance is not squared
+      * the data is initially not L2 normalized
+    """
+    return 1 - x/2.
 
 

--- a/freediscovery/neighbors.py
+++ b/freediscovery/neighbors.py
@@ -1,0 +1,193 @@
+# -*- coding: utf-8 -*-
+
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+from __future__ import unicode_literals
+
+import numpy as np
+
+from sklearn.base import BaseEstimator
+from sklearn.neighbors import NearestNeighbors, NearestCentroid
+from sklearn.utils.validation import check_array
+from .base import RankerMixin
+from .metrics import seuclidean_dist2cosine_sim
+
+# a subclass of the NearestCentroid from scikit-learn that also
+# includes the distance to the nearest centroid
+
+class NearestCentroidRanker(NearestCentroid):
+
+    def decision_function(self, X):
+        """Compute the distances to the nearest centroid for
+        an array of test vectors X.
+
+        Parameters
+        ----------
+        X : array-like, shape = [n_samples, n_features]
+        Returns
+        -------
+        C : array, shape = [n_samples]
+        """
+        from sklearn.metrics.pairwise import pairwise_distances
+        from sklearn.utils.validation import check_array, check_is_fitted
+
+        check_is_fitted(self, 'centroids_')
+
+        X = check_array(X, accept_sparse='csr')
+
+        return pairwise_distances(X, self.centroids_, metric=self.metric).min(axis=1)
+
+def _chunk_kneighbors(func, X, batch_size=5000, **args):
+    """ Chunk kneighbors computations to reduce RAM requirements
+
+    Parameters
+    ----------
+    func : function
+      the function to run
+    X : ndarray
+      the array func is applied to
+    batch_size : int
+      batch size
+
+    Returns
+    -------
+    dist : array
+       distance array
+    ind : array of indices
+    """
+    n_samples = X.shape[0]
+    ind_arr = []
+    dist_arr = []
+    # don't enter the last loop if n_sampes is a multiple of batch_size
+    for k in range(n_samples//batch_size + int(n_samples % batch_size != 0)):
+        mslice = slice(k*batch_size, min((k+1)*batch_size, n_samples))
+        X_sl = X[mslice, :]
+        dist_k, ind_k = func(X_sl, **args)
+        ind_arr.append(ind_k)
+        dist_arr.append(dist_k)
+    return (np.concatenate(dist_arr, axis=0), np.concatenate(ind_arr, axis=0))
+
+
+
+class NearestNeighborRanker(BaseEstimator, RankerMixin):
+    """A nearest neighbor ranker.
+
+    The distance is returned in terms of cosine_similarity
+
+    Parameters
+    ----------
+    radius : float, optional (default = 1.0)
+        Range of parameter space to use by default for :meth:`radius_neighbors`
+        queries.
+
+    algorithm : {'auto', 'ball_tree', 'kd_tree', 'brute'}, optional
+        Algorithm used to compute the nearest neighbors:
+
+        - 'ball_tree' will use :class:`BallTree`
+        - 'kd_tree' will use :class:`KDtree`
+        - 'brute' will use a brute-force search.
+        - 'auto' will attempt to decide the most appropriate algorithm
+          based on the values passed to :meth:`fit` method.
+
+        Note: fitting on sparse input will override the setting of
+        this parameter, using brute force.
+
+    leaf_size : int, optional (default = 30)
+        Leaf size passed to BallTree or KDTree.  This can affect the
+        speed of the construction and query, as well as the memory
+        required to store the tree.  The optimal value depends on the
+        nature of the problem.
+
+    n_jobs : int, optional (default = 1)
+        The number of parallel jobs to run for neighbors search.
+        If ``-1``, then the number of jobs is set to the number of CPU cores.
+
+    method : str, def
+        If "unsupervised" only distances to the positive samples are used in the ranking
+        If "supervised" both the distance to the positive and negative documents are used
+        for ranking (i.e. if a document is slightly further away from a positive document
+        than from a negative one, it will be considered negative with a very low score)
+
+    """
+
+    def __init__(self, radius=1.0,
+                 algorithm='brute', leaf_size=30, n_jobs=1,
+                ):
+
+        self.algorithm = algorithm
+        self.radus = radius
+        self.n_jobs = n_jobs
+        self.leaf_size = leaf_size
+
+    def fit(self, X, y):
+        """Fit the model using X as training data
+        Parameters
+        ----------
+        X : {array-like, sparse matrix, BallTree, KDTree}
+            Training data, shape [n_samples, n_features],
+
+        """
+        X = check_array(X, accept_sparse='csr')
+        y = np.asarray(y, dtype='int')
+        y_unique = np.unique(y)
+
+        index = np.arange(len(y), dtype='int')
+
+        if len(y_unique) == 0:
+            raise ValueError('The training set must have at least one document category!')
+
+        # define nearest neighbors search objects for each category
+        self._mod = [NearestNeighbors(n_neighbors=1,
+                                       leaf_size=self.leaf_size,
+                                       algorithm=self.algorithm,
+                                       n_jobs=self.n_jobs,
+                                       metric='cosine',  # euclidean metric by default
+                                       ) for el in range(len(y_unique))]
+
+        index_mapping = []
+        for imod, y_val in enumerate(y_unique):
+            mask = (y == y_val)
+            index_mapping.append(index[mask])
+            self._mod[imod].fit(X[mask])
+
+        self.index_mapping = index_mapping
+
+
+    def kneighbors(self, X=None, batch_size=5000):
+        """Finds the K-neighbors of a point.
+        Returns indices of and distances to the neighbors of each point.
+        Parameters
+        ----------
+        X : array-like, shape (n_samples, n_features)
+            the input array
+        batch_size : int
+            the batch size
+        Returns
+        -------
+        S_cos : array [n_samples, n_categories]
+            the cosine similarity to closest point in each category
+        indices : array [n_samples, n_categories]
+            Indices of the nearest points in the population matrix.
+        --------
+        """
+        X = check_array(X, accept_sparse='csr')
+
+        n_classes = len(self._mod)
+
+        # cos
+        S_res = np.zeros((X.shape[0], n_classes), dtype='float')
+        nn_idx_res = np.zeros((X.shape[0], n_classes), dtype='int')
+        
+        for imod in range(n_classes):
+            D_i, nn_idx_i_loc = _chunk_kneighbors(self._mod[imod].kneighbors, X,
+                                               batch_size=batch_size)
+
+            # only NearestNeighbor-1 (only one column in the kneighbors output)
+            # convert from eucledian distance in L2 norm space to cosine similarity
+            #S_cos = seuclidean_dist2cosine_sim(D_i[:,0])
+            S_res[:, imod] = 1 - D_i[:, 0]
+            # map local index within index_mapping to global index
+            nn_idx_res[:, imod] = self.index_mapping[imod][nn_idx_i_loc[:,0]]
+
+        return S_res, nn_idx_res

--- a/freediscovery/server/app.py
+++ b/freediscovery/server/app.py
@@ -114,19 +114,19 @@ def fd_app(cache_dir):
     @app.errorhandler(500)
     def handle_error(error):
         #response = jsonify(error.to_dict())
-        response = jsonify({'message': str(error)})
+        response = jsonify({'messages': str(error)})
         response.status_code = 500
         return response
 
     @app.errorhandler(404)
     def handle_404_error(error):
-        response = jsonify({"message": str(error)})
+        response = jsonify({"messages": str(error)})
         response.status_code = 404 
         return response
 
     @app.errorhandler(400)
     def handle_400_error(error):
-        response = jsonify({"message": str(error)})
+        response = jsonify({"messages": str(error)})
         response.status_code = 400
         return response
 

--- a/freediscovery/server/schemas.py
+++ b/freediscovery/server/schemas.py
@@ -41,6 +41,9 @@ class DocumentIndexSchema(Schema):
     render_id = fields.Int()
     file_path = fields.Str()
 
+class DocumentIndexFullSchema(DocumentIndexSchema):
+    file_path = fields.Str()
+
 class DocumentIndexListSchema(Schema):
     internal_id = fields.List(fields.Int())
     document_id = fields.List(fields.Int())
@@ -48,7 +51,7 @@ class DocumentIndexListSchema(Schema):
     file_path = fields.List(fields.Str())
 
 class DocumentIndexNestedSchema(Schema):
-    data = fields.Nested(DocumentIndexSchema, many=True, required=True)
+    data = fields.Nested(DocumentIndexFullSchema, many=True, required=True)
 
 class _DatasetDefinition(Schema):
     document_id = fields.Int()
@@ -112,27 +115,25 @@ class CategorizationPostSchema(ClassificationScoresSchema):
     id = fields.Str(required=True)
 
 class _CategorizationIndex(DocumentIndexSchema):
-    y = fields.Int()
+    category = fields.Int()
 
 class _CategorizationInputSchema(Schema):
     parent_id = fields.Str(required=True)
         # Warning this should be changed to wfields.DelimitedList
         # https://webargs.readthedocs.io/en/latest/api.html#webargs.fields.DelimitedList
-    index = fields.List(fields.Int())
-    y = fields.List(fields.Int())
-    index_nested = fields.Nested(_CategorizationIndex, many=True)
+    data = fields.Nested(_CategorizationIndex, many=True)
     method =  fields.Str(default='LinearSVC')
     cv = fields.Boolean(missing=False)
     training_scores = fields.Boolean(missing=True)
 
+class _CategorizationScoreSchemaElement(DocumentIndexSchema):
+    category = fields.Str(required=True)
+    score = fields.Number(required=True)
 
-class _NNSchemaElement(DocumentIndexSchema):
-    distance = fields.Number(required=True)
 
 class _CategorizationPredictSchemaElement(DocumentIndexSchema):
-    score = fields.Number(required=True)
-    nn_positive = fields.Nested(_NNSchemaElement)
-    nn_negative = fields.Nested(_NNSchemaElement)
+    scores = fields.Nested(_CategorizationScoreSchemaElement(), many=True, required=True)
+
 
 class CategorizationPredictSchema(Schema):
     data = fields.Nested(_CategorizationPredictSchemaElement(), many=True, required=True)

--- a/freediscovery/tests/test_categorize.py
+++ b/freediscovery/tests/test_categorize.py
@@ -15,15 +15,11 @@ from numpy.testing import (assert_allclose, assert_equal,
 
 import pytest
 import itertools
-from sklearn.model_selection import train_test_split
-from sklearn.preprocessing import normalize
 
 from freediscovery.base import PipelineFinder
 from freediscovery.text import FeatureVectorizer
 from freediscovery.lsi import _LSIWrapper
-from freediscovery.categorization import (_CategorizerWrapper, _zip_relevant,
-        _unzip_relevant, NearestNeighborRanker, NearestCentroidRanker,
-        _chunk_kneighbors)
+from freediscovery.categorization import _CategorizerWrapper
 from freediscovery.io import parse_ground_truth_file
 from freediscovery.utils import categorization_score
 from freediscovery.exceptions import OptionalDependencyMissing
@@ -134,20 +130,6 @@ def test_explain_categorization():
     assert len(weights.keys()) < len(vect.vocabulary_) # not all vocabulary keys are returned
 
 
-@pytest.mark.parametrize('batch_size', [1, 101, 100])
-def test_nn_chunking(batch_size):
-
-    shape = (1000, 10)
-
-    X = 2*np.ones(shape)
-    def func(X):
-        assert X.shape[0] > 0 # we need at least one point
-        return X**2, X - 1
-
-    d, idx = _chunk_kneighbors(func, X, batch_size=batch_size)
-
-    assert_allclose(d, 4*np.ones(shape))
-    assert_allclose(idx, 1*np.ones(shape))
 
 
 
@@ -231,138 +213,3 @@ def test_categorization_score():
     scores2 = categorization_score(idx_ref2, y_ref2, idx, y)
     assert scores['average_precision'] == scores2['average_precision']
 
-def test_relevant_zip():
-    relevant_id = [2, 3, 5]
-    non_relevant_id = [1, 7, 10]
-    idx_id = [2, 3, 5, 1, 7, 10]
-    y = [1, 1, 1, 0, 0, 0]
-
-    idx_id2, y2 = _zip_relevant(relevant_id, non_relevant_id)
-    assert_equal(idx_id, idx_id2)
-    assert_equal(y, y2)
-
-    relevant_id2, non_relevant_id2 = _unzip_relevant(idx_id2, y2)
-    assert_equal(relevant_id2, relevant_id)
-    assert_equal(non_relevant_id2, non_relevant_id)
-
-def test_relevant_positives_zip():
-    # Check that _unzip_relavant works with only relevant files
-    idx_id = [2, 3, 5, 1, 7, 10]
-    y = [1, 1, 1, 1, 1, 1]
-    relevant_id2, non_relevant_id2 = _unzip_relevant(idx_id, y)
-    assert_equal(relevant_id2, idx_id)
-    assert_equal(non_relevant_id2, np.array([]))
-
-
-@pytest.mark.parametrize('ranking', ['supervised', 'unsupervised'])
-def test_nearest_neighbor_ranker_supervised(ranking):
-    # check that we have sensible results with respect to
-    # NN1 binary classification (supervised, with both positive
-    # and negative samples)
-    from sklearn.neighbors import KNeighborsClassifier
-    np.random.seed(0)
-
-    n_samples = 1000
-    n_features = 10
-
-    X = np.random.rand(n_samples, n_features)
-    normalize(X, copy=False)
-    index = np.arange(n_samples, dtype='int')
-    y = np.random.randint(0, 2, size=(n_samples,))
-    index_train, index_test, y_train, y_test = train_test_split(index, y)
-    X_train = X[index_train]
-    X_test = X[index_test]
-
-    rk = NearestNeighborRanker(ranking=ranking)
-    rk.fit(X_train, y_train)
-    y_pred, idx, md = rk.kneighbors(X_test, batch_size=90) # choose a batch size smaller
-                                                           # than n_samples
-
-    assert y_pred.shape == (X_test.shape[0],)
-    if ranking == 'supervised':
-        assert y_pred.min() >= -1 and y_pred.min() <= -0.8 # as we are using cosine similarities
-    assert y_pred.max() <=  1 and y_pred.max() >= 0.8
-    assert idx.shape == (X_test.shape[0],)
-    assert sorted(md.keys()) == ['dist_n', 'dist_p', 'ind_n', 'ind_p']
-    for key, val in md.items():
-        assert val.shape == (X_test.shape[0],)
-        assert_array_less(0, val) # all values are positive
-
-    # postive scores correspond to positive documents
-
-    if ranking == 'supervised':
-        assert_equal((y_pred > 0), y_train[idx])
-
-        cl = KNeighborsClassifier(n_neighbors=1, algorithm='brute')
-        cl.fit(X_train, y_train)
-
-        y_ref = cl.predict(X_test)
-
-        # make sure we get the same results as for the KNeighborsClassifier
-        assert_equal(y_ref, y_train[idx])
-    else:
-        assert_allclose(y_pred, 1 - md['dist_p']/2)
-        assert_array_equal(idx, md['ind_p'])
-
-def test_nearest_neighbor_ranker_unsupervised():
-    # Check NearestNeighborRanker with only positive samples
-    # (unsupervised)
-    from sklearn.neighbors import NearestNeighbors
-    np.random.seed(0)
-
-    n_samples = 1000
-    n_features = 120
-
-    X = np.random.rand(n_samples, n_features)
-    normalize(X, copy=False)
-    index = np.arange(n_samples, dtype='int')
-    y = np.ones(n_samples, dtype=np.int)
-    index_train, index_test, y_train, y_test = train_test_split(index, y)
-    X_train = X[index_train]
-    X_test = X[index_test]
-
-    rk = NearestNeighborRanker()
-    rk.fit(X_train, y_train)
-    y_pred, idx, md = rk.kneighbors(X_test)
-
-    assert_array_less(0, y_pred) # all distance are positive
-
-    nn = NearestNeighbors(n_neighbors=1, algorithm='brute')
-    nn.fit(X_train)
-    dist, idx_ref = nn.kneighbors(X_test)
-
-    assert_equal(idx, idx_ref[:,0])
-
-    assert_equal(y_pred, (1 - dist[:,0]/4))
-
-def test_nearest_centroid_ranker():
-    # in the case where there is a single point by centroid,
-    # nearest centroid should reduce to nearest neighbor
-    from sklearn.neighbors import NearestNeighbors
-    np.random.seed(0)
-
-    n_samples = 100
-    n_features = 120
-    X = np.random.rand(n_samples, n_features)
-    normalize(X, copy=False)
-    index = np.arange(n_samples, dtype='int')
-    y = np.arange(n_samples, dtype='int')
-    index_train, index_test, y_train, y_test = train_test_split(index, y)
-    X_train = X[index_train]
-    X_test = X[index_test]
-
-
-    nn = NearestNeighbors(n_neighbors=1, algorithm='brute')
-    nn.fit(X_train)
-    dist_ref, idx_ref = nn.kneighbors(X_test)
-
-    nc = NearestCentroidRanker()
-    nc.fit(X_train, y_train)
-    dist_pred = nc.decision_function(X_test)
-    y_pred = nc.predict(X_test)
-
-    # ensures that we have the same number of unique ouput points
-    # (even if absolute labels are not preserved)
-    assert np.unique(idx_ref[:,0]).shape ==  np.unique(y_pred).shape
-
-    assert_allclose(dist_pred, dist_ref[:,0])

--- a/freediscovery/tests/test_categorize.py
+++ b/freediscovery/tests/test_categorize.py
@@ -78,7 +78,7 @@ def test_categorization(use_lsi, method, cv):
     index = cat.fe.db._search_filenames(ground_truth.file_path.values)
 
     try:
-        coefs, Y_train = cat.train(
+        model, Y_train = cat.train(
                                 index,
                                 ground_truth.is_relevant.values,
                                 method=method,
@@ -94,16 +94,16 @@ def test_categorization(use_lsi, method, cv):
 
     scores = categorization_score(idx_gt,
                         ground_truth.is_relevant.values,
-                        X_pred, Y_pred)
+                        X_pred, np.argmax(Y_pred, axis=1))
 
     assert cat.get_params() is not None
 
+    assert Y_pred.shape == (cat.fe.n_samples_, len(np.unique(ground_truth.is_relevant.values)))
+
     if method == 'NearestNeighbor':
-        assert sorted(list(md.keys())) == ['dist_n', 'dist_p', 'ind_n', 'ind_p']
-        for key, val in md.items():
-            assert val.shape == Y_pred.shape
+        assert md.shape == Y_pred.shape
     else:
-        assert md == {}
+        assert md is None
 
     if method in ['xgboost', 'ensemble-stacking']:
         # this parameter fail for some reason so far...

--- a/freediscovery/tests/test_integration.py
+++ b/freediscovery/tests/test_integration.py
@@ -79,7 +79,7 @@ def test_features_hashing(use_hashing, use_lsi, method):
 
         scores = categorization_score(idx_gt,
                             ground_truth.is_relevant.values,
-                            X_pred, Y_pred)
+                            X_pred, np.argmax(Y_pred, axis=1))
         assert_allclose(scores['precision'], 1, rtol=0.5)
         assert_allclose(scores['recall'], 1, rtol=0.7)
         cat.delete()

--- a/freediscovery/tests/test_metrics.py
+++ b/freediscovery/tests/test_metrics.py
@@ -46,13 +46,3 @@ def test_euclidean2cosine():
     D_seuc = pairwise_distances(x, y, metric='euclidean', squared=True)[0, 0]
 
     assert_allclose(S_cos, seuclidean_dist2cosine_sim(D_seuc))
-
-
-
-
-
-
-
-
-
-

--- a/freediscovery/tests/test_metrics.py
+++ b/freediscovery/tests/test_metrics.py
@@ -8,13 +8,15 @@ import os.path
 import numpy as np
 from numpy.testing import assert_allclose, assert_equal
 import pytest
+from sklearn.preprocessing import normalize
 
 from freediscovery.text import FeatureVectorizer
 from .run_suite import check_cache
 
 from freediscovery.metrics import (ratio_duplicates_score,
                                    f1_same_duplicates_score,
-                                   mean_duplicates_count_score)
+                                   mean_duplicates_count_score,
+                                   seuclidean_dist2cosine_sim)
 
 def test_duplicate_metrics():
     x1 = np.array([0, 1, 1, 2, 3, 2])
@@ -33,5 +35,24 @@ def test_duplicate_metrics():
     assert mean_duplicates_count_score(x1, x2) == 1.0
     assert mean_duplicates_count_score(x1, x3) == 0.5
     assert mean_duplicates_count_score(x1, x4) == 0.75
+
+def test_euclidean2cosine():
+    from sklearn.metrics.pairwise import pairwise_distances
+    x = normalize([[0, 2, 3, 5]])
+    y = normalize([[1, 3, 6, 7]])
+
+    D_cos = pairwise_distances(x, y, metric='cosine')[0, 0]
+    S_cos = 1 - D_cos
+    D_seuc = pairwise_distances(x, y, metric='euclidean', squared=True)[0, 0]
+
+    assert_allclose(S_cos, seuclidean_dist2cosine_sim(D_seuc))
+
+
+
+
+
+
+
+
 
 

--- a/freediscovery/tests/test_neighbors.py
+++ b/freediscovery/tests/test_neighbors.py
@@ -1,0 +1,143 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+#from __future__ import unicode_literals
+
+import os.path
+from unittest import SkipTest
+import re
+
+import numpy as np
+from numpy.testing import (assert_allclose, assert_equal,
+                           assert_array_less, assert_array_equal)
+
+import pytest
+import itertools
+from sklearn.model_selection import train_test_split
+from sklearn.preprocessing import normalize
+from sklearn.externals import joblib
+
+from freediscovery.neighbors import ( NearestNeighborRanker, NearestCentroidRanker,
+                                        _chunk_kneighbors)
+from .run_suite import check_cache
+
+
+basename = os.path.dirname(__file__)
+
+
+cache_dir = check_cache()
+
+@pytest.mark.parametrize('n_categories', [1, 2, 3, 4])
+def test_nearest_neighbor_ranker(n_categories):
+    # check that we have sensible results with respect to
+    # NN1 binary classification (supervised, with both positive
+    # and negative samples)
+    from sklearn.neighbors import KNeighborsClassifier
+    from sklearn.neighbors import NearestNeighbors
+    np.random.seed(0)
+
+    n_samples = 110
+    n_features = 10
+
+    X = np.random.rand(n_samples, n_features)
+    normalize(X, copy=False)
+    index = np.arange(n_samples, dtype='int')
+    y = np.random.randint(0, n_categories, size=(n_samples,))
+    index_train, index_test, y_train, y_test = train_test_split(index, y)
+    X_train = X[index_train]
+    X_test = X[index_test]
+
+    rk = NearestNeighborRanker()
+    rk.fit(X_train, y_train)
+    y_pred, idx_pred = rk.kneighbors(X_test, batch_size=90) # choose a batch size smaller
+                                                           # than n_samples
+
+    assert y_pred.shape == (X_test.shape[0], n_categories)
+    assert y_pred.min() >= -1 and y_pred.max() <= 1 # as we are using cosine similarities
+    assert idx_pred.shape == (X_test.shape[0], n_categories)
+
+    # postive scores correspond to positive documents
+
+    #assert_equal((y_pred > 0), y_train[idx])
+
+    cl = KNeighborsClassifier(n_neighbors=1, algorithm='brute', metric='cosine')
+    cl.fit(X_train, y_train)
+
+    idx_ref_cl = cl.predict(X_test)
+
+    # make sure we get the same results as for the KNeighborsClassifier
+    label_pred = np.argmax(y_pred, axis=1)
+    assert_equal(label_pred, idx_ref_cl)
+
+    nn = NearestNeighbors(n_neighbors=1, algorithm='brute', metric='cosine')
+    nn.fit(X_train)
+    S_ref_nn, idx_ref_nn = nn.kneighbors(X_test)
+
+    assert_equal(idx_pred[range(len(label_pred)), label_pred], idx_ref_nn[:,0])
+    assert_allclose(np.max(y_pred, axis=1)[:, None], 1 - S_ref_nn)
+
+
+def test_nearest_neighbor_ranker_is_picklable():
+    mod = NearestNeighborRanker()
+
+    mod.fit([[0, 1], [1, 0]], [0, 1])
+
+    try:
+        tmp_file = os.path.join(cache_dir, 'tmp_NearestNeighborRanker.pkl')
+        joblib.dump(mod, tmp_file)
+
+        mod2 = joblib.load(tmp_file)
+    finally:
+        if os.path.exists(tmp_file):
+            os.remove(tmp_file)
+
+
+def test_nearest_centroid_ranker():
+    # in the case where there is a single point by centroid,
+    # nearest centroid should reduce to nearest neighbor
+    from sklearn.neighbors import NearestNeighbors
+    np.random.seed(0)
+
+    n_samples = 100
+    n_features = 120
+    X = np.random.rand(n_samples, n_features)
+    normalize(X, copy=False)
+    index = np.arange(n_samples, dtype='int')
+    y = np.arange(n_samples, dtype='int')
+    index_train, index_test, y_train, y_test = train_test_split(index, y)
+    X_train = X[index_train]
+    X_test = X[index_test]
+
+
+    nn = NearestNeighbors(n_neighbors=1, algorithm='brute')
+    nn.fit(X_train)
+    dist_ref, idx_ref = nn.kneighbors(X_test)
+
+    nc = NearestCentroidRanker()
+    nc.fit(X_train, y_train)
+    dist_pred = nc.decision_function(X_test)
+    y_pred = nc.predict(X_test)
+
+    # ensures that we have the same number of unique ouput points
+    # (even if absolute labels are not preserved)
+    assert np.unique(idx_ref[:,0]).shape ==  np.unique(y_pred).shape
+
+    assert_allclose(dist_pred, dist_ref[:,0])
+
+
+@pytest.mark.parametrize('batch_size', [1, 101, 100])
+def test_nn_chunking(batch_size):
+
+    shape = (1000, 10)
+
+    X = 2*np.ones(shape)
+    def func(X):
+        assert X.shape[0] > 0 # we need at least one point
+        return X**2, X - 1
+
+    d, idx = _chunk_kneighbors(func, X, batch_size=batch_size)
+
+    assert_allclose(d, 4*np.ones(shape))
+    assert_allclose(idx, 1*np.ones(shape))

--- a/freediscovery/tests/test_utils.py
+++ b/freediscovery/tests/test_utils.py
@@ -35,3 +35,47 @@ def test_docstring_description():
 
     assert len(res.splitlines()) == 21
 
+def test_dictkey2type():
+    from freediscovery.utils import dict2type
+
+    assert dict2type('djsk')  == 'str'
+    assert dict2type(['t', 1]) == ['str', 'int']
+    assert dict2type({'t': {'b': 0.1}}) == {'t': {'b': 'float'}}
+
+
+def test_check_dict():
+    from freediscovery.utils import assert_equal_dict_keys
+
+    a = {'a': 3, 'b': 2}
+    b = {'b': 3, 'a': 2}
+
+    assert_equal_dict_keys(a, b)
+
+    a = {'a': 3, 'd': 2}
+    b = {'b': 3, 'a': 2}
+
+    with pytest.raises(AssertionError):
+        assert_equal_dict_keys(a, b)
+
+    a = {'a': 3, 'b': 2, 'c': {'x': 3}}
+    b = {'b': 3, 'a': 2, 'c': {'x': -1}}
+
+    assert_equal_dict_keys(a, b)
+
+    a = {'a': 3, 'b': 2, 'c': {'z': 3}}
+    b = {'b': 3, 'a': 2, 'c': {'x': -1}}
+
+    with pytest.raises(AssertionError):
+        assert_equal_dict_keys(a, b)
+
+    a = {'a': [{'a': 3}, {'a': 4}]}
+    b = {'a': [{'a': 4}, {'b': 9}]}
+
+    # this test passes as the list does not have a dict with the same keys
+    assert_equal_dict_keys(a, b)
+
+    a = {'a': [{'a': 3}, {'a': 4}]}
+    b = {'a': [{'b': 4}, {'b': 9}]}
+
+    with pytest.raises(AssertionError):
+        assert_equal_dict_keys(a, b)


### PR DESCRIPTION
This PR allows to perform multi-class categorization with FreeDiscovery (issue #87) and changes the REST API accordingly. It also allows to set a limit on the number of returned categories (issue #88 ).