### PR TITLE
Encode GET request parameters in the URL string

### DIFF
--- a/examples/REST_categorization.py
+++ b/examples/REST_categorization.py
@@ -25,7 +25,7 @@ if __name__ == '__main__':
     print(" 0. Load the example dataset")
     url = BASE_URL + '/example-dataset/{}'.format(dataset_name)
     print(" GET", url)
-    input_ds = requests.get(url, json={'train_set_fields': ['document_id']}).json()
+    input_ds = requests.get(url, params={'train_set_fields': ['document_id']}).json()
 
 
     data_dir = input_ds['metadata']['data_dir']

--- a/freediscovery/server/schemas.py
+++ b/freediscovery/server/schemas.py
@@ -152,7 +152,7 @@ class _HTreeSchema(Schema):
 
 class ClusteringSchema(Schema):
     labels = fields.List(fields.Int(), required=True)
-    cluster_terms = fields.List(fields.Str(), required=True)
+    cluster_terms = fields.List(fields.List(fields.Str()), required=True)
     htree = fields.Nested(_HTreeSchema()) 
     pars = fields.Str(required=True)
 

--- a/freediscovery/server/tests/test_clustering.py
+++ b/freediscovery/server/tests/test_clustering.py
@@ -60,11 +60,13 @@ def test_api_clustering(app, model, use_lsi):
     mid = data['id']
 
     url += '/{}'.format(mid)
-    res = app.get(url)
+    n_top_words = 2
+    res = app.get(url, query_string={'n_top_words': n_top_words})
     assert res.status_code == 200
     data = parse_res(res)
     assert sorted(data.keys()) == \
             sorted(['cluster_terms', 'labels', 'pars', 'htree'])
+    assert len(data['cluster_terms'][0]) == 2
 
     if data['htree']:
         assert sorted(data['htree'].keys()) == \

--- a/freediscovery/server/tests/test_duplicate_detection.py
+++ b/freediscovery/server/tests/test_duplicate_detection.py
@@ -54,7 +54,7 @@ def test_api_dupdetection(app, kind, options):
     mid = data['id']
 
     url += '/{}'.format(mid)
-    res = app.get(url, data=options)
+    res = app.get(url, query_string=options)
     assert res.status_code == 200
     data = parse_res(res)
     assert sorted(data.keys()) == sorted(['cluster_id'])


### PR DESCRIPTION
Since GET endpoints cannot accept parameters in the payload, this PR ensures that the corresponding parameters are passed in the URL string.