### PR TITLE
Refactoring of the clustering / dup. detection API

### DIFF
--- a/doc/Makefile
+++ b/doc/Makefile
@@ -52,6 +52,7 @@ clean:
 	rm -rf $(BUILDDIR)/*
 	rm -rf examples/
 	rm -rf modules/generated/*
+	rm -rf generated/*
 
 
 html:

--- a/doc/python_api.rst
+++ b/doc/python_api.rst
@@ -71,7 +71,7 @@ Email threading
 .. autosummary::
     :toctree: ./generated/
 
-    freediscovery.threading._EmailThreadingWrapper
+    freediscovery.email_threading._EmailThreadingWrapper
     
 Semantic search
 ---------------

--- a/doc/whats_new.md
+++ b/doc/whats_new.md
@@ -7,6 +7,7 @@
 ### New features  
 
  * Support for multi-class categorization and non integer class labels (PR [#96](https://github.com/FreeDiscovery/FreeDiscovery/pull/96/files)) 
+ * In the case of binary categorization, recall at 20 % of documents is computed as part of the list of default scores (PR [#106](https://github.com/FreeDiscovery/FreeDiscovery/pull/106))
 
 ### Enhancements
 

--- a/doc/whats_new.md
+++ b/doc/whats_new.md
@@ -14,7 +14,7 @@
  * Categorization and semantic search support sorting and filtering of documents below a user provided threashold. (PR [#96](https://github.com/FreeDiscovery/FreeDiscovery/pull/96/files))
  * The similarity and ML scores can now be scaled to [0, 1] range using `nn_metric` and `ml_output` input parameters (PR [#101](https://github.com/FreeDiscovery/FreeDiscovery/pull/100/files)).
  * The REST API documentation is generated automatically from the code (using an OpenAPI specification) which allows to enforce consistency between the code and the docs (PR [#85](https://github.com/FreeDiscovery/FreeDiscovery/pull/85))
- 
+ * Adapted clustering and duplicate detection to reuturn documents indexed by `document_id`, `rendering_id`
 
 
 ### API Changes

--- a/doc/whats_new.md
+++ b/doc/whats_new.md
@@ -14,7 +14,7 @@
  * Categorization and semantic search support sorting and filtering of documents below a user provided threashold. (PR [#96](https://github.com/FreeDiscovery/FreeDiscovery/pull/96/files))
  * The similarity and ML scores can now be scaled to [0, 1] range using `nn_metric` and `ml_output` input parameters (PR [#101](https://github.com/FreeDiscovery/FreeDiscovery/pull/100/files)).
  * The REST API documentation is generated automatically from the code (using an OpenAPI specification) which allows to enforce consistency between the code and the docs (PR [#85](https://github.com/FreeDiscovery/FreeDiscovery/pull/85))
- * Adapted clustering and duplicate detection to reuturn documents indexed by `document_id`, `rendering_id`
+ * Adapted clustering and duplicate detection to return structured objects indexed by `document_id`( and optionally `rendering_id`)
 
 
 ### API Changes

--- a/examples/REST_duplicate_detection.py
+++ b/examples/REST_duplicate_detection.py
@@ -83,7 +83,7 @@ print(" POST", url)
 t0 = time()
 res = requests.post(url,
         json={'parent_id': lsi_id,
-              'eps': 0.35,            # 2*cosine distance for documents to be considered as duplicates
+              'min_similarity': 0.90,            # 2*cosine distance for documents to be considered as duplicates
               'n_max_samples': 2
               }).json()
 
@@ -100,7 +100,8 @@ t1 = time()
 print('    .. computed in {:.1f}s'.format(t1 - t0))
 
 data = res['data']
-print('Found {} duplicates / {}'.format(sum([len(row['documents']) for row in data]),
+print('Found {} duplicates / {}'.format(sum([len(row['documents']) for row in data \
+                                            if len(row['documents']) > 1]),
                                         len(input_ds['dataset'])))
 
 

--- a/examples/REST_duplicate_detection.py
+++ b/examples/REST_duplicate_detection.py
@@ -99,9 +99,9 @@ t1 = time()
 
 print('    .. computed in {:.1f}s'.format(t1 - t0))
 
-labels_ = res['labels']
-
-print('Found {} duplicates / {}'.format(len(labels_) - len(np.unique(labels_)), len(labels_)))
+data = res['data']
+print('Found {} duplicates / {}'.format(sum([len(row['documents']) for row in data]),
+                                        len(input_ds['dataset'])))
 
 
 print("\n3. Near Duplicates Detection using I-Match")

--- a/examples/REST_duplicate_detection.py
+++ b/examples/REST_duplicate_detection.py
@@ -130,9 +130,10 @@ res = requests.get(url,
 t1 = time()
 print('    .. computed in {:.1f}s'.format(time() - t0))
 
-labels_ = res['cluster_id']
+data = res['data']
 
-print('Found {} duplicates / {}'.format(len(labels_) - len(np.unique(labels_)), len(labels_)))
+print('Found {} duplicates / {}'.format(sum([len(row['documents']) for row in data]),
+                                        len(input_ds['dataset'])))
 
 
 
@@ -166,9 +167,10 @@ res = requests.get(url,
 data = res.json()
 print('    .. computed in {:.1f}s'.format(time() - t0))
 
-labels_ = data['cluster_id']
+data = data['data']
 
-print('Found {} duplicates / {}'.format(len(labels_) - len(np.unique(labels_)), len(labels_)))
+print('Found {} duplicates / {}'.format(sum([len(row['documents']) for row in data]),
+                                        len(input_ds['dataset'])))
 
 
 

--- a/freediscovery/categorization.py
+++ b/freediscovery/categorization.py
@@ -363,8 +363,6 @@ class _CategorizerWrapper(_BaseWrapper):
                     iscores.append(iiel)
             ires['scores'] = iscores
             res.append(ires)
-            #import json
-            #print(json.dumps(res, indent=4))
         if sort:
             res = sorted(res, key=lambda x: x['scores'][0]['score'], reverse=True)
         return {'data': res}

--- a/freediscovery/cluster/base.py
+++ b/freediscovery/cluster/base.py
@@ -326,7 +326,7 @@ class _ClusteringWrapper(_BaseWrapper, _BaseClusteringWrapper):
         return self._cluster_func(n_clusters, km, pars)
 
 
-    def birch(self, n_clusters, threshold=0.5):
+    def birch(self, n_clusters, threshold=0.5, branching_factor=50):
         """
         Perform Birch clustering
 
@@ -344,7 +344,8 @@ class _ClusteringWrapper(_BaseWrapper, _BaseClusteringWrapper):
         if 'lsi' not in self.pipeline:
             raise ValueError("you must use lsi with birch clustering for scaling reasons.")
 
-        km = Birch(n_clusters=n_clusters, threshold=threshold)
+        km = Birch(n_clusters=n_clusters, threshold=threshold,
+                branching_factor=branching_factor)
 
         return self._cluster_func(n_clusters, km, pars)
 

--- a/freediscovery/cluster/base.py
+++ b/freediscovery/cluster/base.py
@@ -135,8 +135,33 @@ class ClusterLabels(object):
         #"else:
         #"    silhouette_score_res = np.nan # this takes too much memory to compute with the raw matrix
 
+class _BaseClusteringWrapper(object):
 
-class _ClusteringWrapper(_BaseWrapper):
+    def centroid_similarity(self, internal_ids, nn_metric='jaccard_norm'):
+        """ Given a list of documents in a cluster, compute the cluster centroid,
+        intertia and individual distances 
+
+        Parameters
+        ----------
+        internal_ids : list
+          a list of internal ids
+        nn_metric : str
+          a rescaling of the metric if needed
+        """
+        from ..metrics import _scale_cosine_similarity
+        from sklearn.metrics.pairwise import pairwise_distances
+        X = self._fit_X
+
+        X_sl = X[internal_ids, :]
+        centroid = X_sl.mean(axis=0)
+
+        S_cos = 1 - pairwise_distances(X_sl, centroid, metric='cosine')
+        S_sim = _scale_cosine_similarity(S_cos, metric=nn_metric)
+        S_sim_mean = np.mean(S_sim)
+        return S_sim_mean, S_sim[:,0]
+
+
+class _ClusteringWrapper(_BaseWrapper, _BaseClusteringWrapper):
     """Document clustering
 
     The algorithms are adapted from scikit learn.

--- a/freediscovery/dupdet/base.py
+++ b/freediscovery/dupdet/base.py
@@ -14,8 +14,9 @@ from ..text import FeatureVectorizer
 from ..utils import setup_model, _rename_main_thread
 from ..exceptions import (DatasetNotFound, ModelNotFound, InitException,
                             WrongParameter)
+from ..cluster.base import _BaseClusteringWrapper
 
-class _DuplicateDetectionWrapper(_BaseWrapper):
+class _DuplicateDetectionWrapper(_BaseWrapper, _BaseClusteringWrapper):
     """Find near duplicates in a document collection.
 
     Currently supported backends are simhash-py and i-match.

--- a/freediscovery/server/app.py
+++ b/freediscovery/server/app.py
@@ -106,7 +106,7 @@ def fd_app(cache_dir):
 
         ressource_name = resource_el.__name__
         app.add_url_rule('/api/v0' + url, view_func=resource_el.as_view(ressource_name))
-        if ressource_name not in [ "EmailThreadingApi" ]:
+        if ressource_name not in ["EmailThreadingApi" ]:
             # the above two cases fail due to recursion limit
             docs.register(resource_el, endpoint=ressource_name)
 

--- a/freediscovery/server/resources.py
+++ b/freediscovery/server/resources.py
@@ -35,7 +35,7 @@ from ..cluster import _ClusteringWrapper
 from ..search import _SearchWrapper
 from ..metrics import (categorization_score,
                        ratio_duplicates_score, f1_same_duplicates_score,
-                       mean_duplicates_count_score)
+                       mean_duplicates_count_score, _scale_cosine_similarity)
 from ..dupdet import _DuplicateDetectionWrapper
 from ..email_threading import _EmailThreadingWrapper
 from ..datasets import load_dataset
@@ -459,11 +459,6 @@ class KmeanClusteringApi(Resource):
         return {'id': cl.mid}
 
 
-_birch_clustering_api_post_args = {
-        'parent_id': wfields.Str(required=True),
-        'n_clusters': wfields.Int(missing=150),
-        'threshold': wfields.Number(),
-        }
 
 
 class BirchClusteringApi(Resource):
@@ -476,15 +471,32 @@ class BirchClusteringApi(Resource):
            **Parameters**
             - `parent_id`: `dataset_id` or `lsi_id`
             - `n_clusters`: the number of clusters
-            - `threshold`: The radius of the subcluster obtained by merging a new sample and the closest subcluster should be lesser than the threshold. Otherwise a new subcluster is started. See [sklearn.cluster.Birch](http://scikit-learn.org/stable/modules/generated/sklearn.cluster.Birch.html)
+            - `min_similarity`: The radius of the subcluster obtained by merging a new sample and the closest subcluster should be lesser than the threshold. Otherwise a new subcluster is started. See [sklearn.cluster.Birch](http://scikit-learn.org/stable/modules/generated/sklearn.cluster.Birch.html)
+            - `branching_factor`: Maximum number of CF subclusters in each node. If a new samples enters such that the number of subclusters exceed the branching_factor then the node has to be split. The corresponding parent also has to be split and if the number of subclusters in the parent is greater than the branching factor, then it has to be split recursively.
+            - `nn_metric` : The similarity returned by nearest neighbor classifier in ['cosine', 'jaccard', 'cosine_norm', 'jaccard_norm'].
            """))
-    @use_args(_birch_clustering_api_post_args)
+    @use_args( {
+            'parent_id': wfields.Str(required=True),
+            'n_clusters': wfields.Int(missing=150),
+            'branching_factor': wfields.Int(missing=50),
+            'min_similarity': wfields.Number(missing=0.75), # this corresponds approximately to threashold = 0.5
+            'nn_metric': wfields.Str(missing='jaccard_norm')
+            }
+            )
     @marshal_with(IDSchema())
     def post(self, **args):
+        from math import sqrt
+        
 
-        cl = _ClusteringWrapper(cache_dir=self._cache_dir, parent_id=args['parent_id'])
-        del args['parent_id']
-        cl.birch(**args)
+        S_cos = _scale_cosine_similarity(args.pop('min_similarity'),
+                                         metric=args.pop('nn_metric'),
+                                         inverse=True)
+        # cosine sim to euclidean distance
+        threshold = sqrt(2 *(1 - S_cos))
+
+        cl = _ClusteringWrapper(cache_dir=self._cache_dir,
+                                parent_id=args.pop('parent_id'))
+        cl.birch(threshold=threshold, **args)
         return {'id': cl.mid}
 
 
@@ -524,11 +536,6 @@ class WardHCClusteringApi(Resource):
         cl.ward_hc(**args)
         return {'id': cl.mid}
 
-_dbscan_clustering_api_post_args = {
-        'parent_id': wfields.Str(required=True),
-        'eps': wfields.Number(missing=0.1),
-        'min_samples': wfields.Int(missing=10)
-        }
 
 
 class DBSCANClusteringApi(Resource):
@@ -540,18 +547,27 @@ class DBSCANClusteringApi(Resource):
 
            **Parameters**
              - `parent_id`: `dataset_id` or `lsi_id`
-             - `eps`: (optional) float The maximum distance between two samples for them to be considered as in the same neighborhood.
+             - `min_similarity`: The radius of the subcluster obtained by merging a new sample and the closest subcluster should be lesser than the threshold. Otherwise a new subcluster is started. See [sklearn.cluster.Birch](http://scikit-learn.org/stable/modules/generated/sklearn.cluster.Birch.html)
+             - `nn_metric` : The similarity returned by nearest neighbor classifier in ['cosine', 'jaccard', 'cosine_norm', 'jaccard_norm'].
              - `min_samples`: (optional) int The number of samples (or total weight) in a neighborhood for a point to be considered as a core point. This includes the point itself.
             """))
-    @use_args(_dbscan_clustering_api_post_args)
+    @use_args({ 'parent_id': wfields.Str(required=True),
+                'min_samples': wfields.Int(missing=10),
+                'min_similarity': wfields.Number(missing=0.75), # this corresponds approximately to threashold = 0.5
+                'nn_metric': wfields.Str(missing='jaccard_norm')
+                })
     @marshal_with(IDSchema())
     def post(self, **args):
+        from math import sqrt
+        S_cos = _scale_cosine_similarity(args.pop('min_similarity'),
+                                         metric=args.pop('nn_metric'),
+                                         inverse=True)
+        # cosine sim to euclidean distance
+        eps = sqrt(2 *(1 - S_cos))
 
-        cl = _ClusteringWrapper(cache_dir=self._cache_dir, parent_id=args['parent_id'])
+        cl = _ClusteringWrapper(cache_dir=self._cache_dir, parent_id=args.pop('parent_id'))
 
-        del args['parent_id']
-
-        cl.dbscan(**args)
+        cl.dbscan(eps=eps, **args)
         return {'id': cl.mid}
 
 
@@ -590,8 +606,6 @@ class ClusteringApiElement(Resource):
         valid_keys = ['document_id', 'rendering_id', 'similarity']
         for name, group in y.groupby('cluster_id'):
             name = int(name)
-            if group.shape[0] <= 1:
-                continue
 
             S_sim_mean, S_sim = cl.centroid_similarity(group.index.values, nn_metric)
             group = group.assign(similarity=S_sim)

--- a/freediscovery/server/schemas.py
+++ b/freediscovery/server/schemas.py
@@ -153,11 +153,16 @@ class ClusteringSchema(Schema):
     htree = fields.Nested(_HTreeSchema()) 
     pars = fields.Str(required=True)
 
-class DuplicateDetectionSchema(Schema):
-    simhash = fields.List(fields.Int(), required=True)
-    cluster_id = fields.List(fields.Int(), required=True)
-    dup_pairs = fields.List(fields.List(fields.Int()), required=True)
+class _ClusteringElementSubSchema(DocumentIndexSchema):
+    similarity = fields.Number()
 
+class _ClusteringElementSchema(DocumentIndexSchema):
+    cluster_id = fields.Int(required=True)
+    cluster_similarity = fields.Number()
+    documents = fields.Nested(_ClusteringElementSubSchema, many=True, required=True)
+
+class DuplicateDetectionSchema(Schema):
+    data = fields.Nested(_ClusteringElementSchema, many=True, required=True)
 
 class EmailThreadingParsSchema(Schema):
     group_by_subject = fields.Boolean(required=True)

--- a/freediscovery/server/schemas.py
+++ b/freediscovery/server/schemas.py
@@ -140,28 +140,18 @@ class CategorizationParsSchema(Schema):
     method = fields.Str(required=True)
     options = fields.Str(required=True)
 
-
-class _HTreeSchema(Schema):
-    n_leaves = fields.Int(required=True)
-    n_components = fields.Int(required=True)
-    children = fields.List(fields.List(fields.Int), required=True)
-
-
-class ClusteringSchema(Schema):
-    labels = fields.List(fields.Int(), required=True)
-    cluster_terms = fields.List(fields.List(fields.Str()), required=True)
-    htree = fields.Nested(_HTreeSchema()) 
-    pars = fields.Str(required=True)
-
 class _ClusteringElementSubSchema(DocumentIndexSchema):
     similarity = fields.Number()
 
 class _ClusteringElementSchema(DocumentIndexSchema):
     cluster_id = fields.Int(required=True)
     cluster_similarity = fields.Number()
+    cluster_label = fields.Str()
+    cluster_depth = fields.Int()
+    children = fields.List(fields.Int())
     documents = fields.Nested(_ClusteringElementSubSchema, many=True, required=True)
 
-class DuplicateDetectionSchema(Schema):
+class ClusteringSchema(Schema):
     data = fields.Nested(_ClusteringElementSchema, many=True, required=True)
 
 class EmailThreadingParsSchema(Schema):
@@ -174,7 +164,7 @@ class TreeSchema(Schema):
     id = fields.Int(required=True)
     parent = fields.Int(allow_none=True, required=True)
     subject = fields.Str()
-    children = fields.Nested('self', many=True, required=True)
+    children = fields.Nested('self', many=True)
 
 
 class EmailThreadingSchema(Schema):

--- a/freediscovery/tests/test_metrics.py
+++ b/freediscovery/tests/test_metrics.py
@@ -50,7 +50,8 @@ def test_euclidean2cosine():
 
 def test_cosine2jaccard():
     from sklearn.metrics.pairwise import pairwise_distances
-    from freediscovery.metrics import cosine2jaccard_similarity
+    from freediscovery.metrics import (cosine2jaccard_similarity,
+                                       jaccard2cosine_similarity)
 
     x = np.array([[0, 0, 1., 1.]])
     y = np.array([[0, 1., 1., 0]])
@@ -60,6 +61,9 @@ def test_cosine2jaccard():
     S_jac_ref = 1 - pairwise_distances(x.astype('bool'), y.astype('bool'), metric='jaccard')
 
     assert_allclose(S_jac, S_jac_ref)
+
+    S_cos2 = jaccard2cosine_similarity(S_jac)
+    assert_allclose(S_cos2, S_cos)
 
 @pytest.mark.parametrize('metric', ['cosine', 'jaccard', 'cosine_norm', 'jaccard_norm']) 
 def test_cosine_jaccard_norm(metric):
@@ -71,6 +75,8 @@ def test_cosine_jaccard_norm(metric):
         assert_allclose(S_res, S_cos)
     elif metric == 'jaccard':
         assert_allclose(S_res, 0.5, rtol=0.1)
+    S_res2 = _scale_cosine_similarity(S_res, metric=metric, inverse=True)
+    assert_allclose(S_res2, S_cos, rtol=0.1)
 
 
 def test_recall_at_k_score():


### PR DESCRIPTION
This PR refactors the clustering and duplicate detection API in order to remove the need for manual document id mapping as was previously done for categorization and semantic search. This also affects PR #75 .