### PR TITLE
DELETE custom stop words endpoint

### DIFF
--- a/freediscovery/server/resources.py
+++ b/freediscovery/server/resources.py
@@ -991,5 +991,12 @@ class CustomStopWordsApi(Resource):
 class CustomStopWordsLoadApi(Resource):
 
     @doc(description="Load a stored list of stop words")
+    @marshal_with(CustomStopWordsLoadSchema())
     def get(self, name):
         return {'name': name, 'stop_words': _StopWordsWrapper(cache_dir=self._cache_dir).load(name)}
+
+    @doc(description='Delete a stored custom stop words')
+    @marshal_with(EmptySchema())
+    def delete(self, name):
+        _StopWordsWrapper(cache_dir=self._cache_dir).delete(name)
+        return {}

--- a/freediscovery/server/tests/test_custom_stop_words.py
+++ b/freediscovery/server/tests/test_custom_stop_words.py
@@ -41,3 +41,7 @@ def test_stop_words(app):
 
     assert dict2type(data, collapse_lists=True) == {'name': 'str', 'stop_words': ['str']}
     assert data["stop_words"] == tested_stop_words
+
+    method = V01 + "/stop-words/{}".format(name)
+    res = app.delete(method)
+    assert res.status_code == 200

--- a/freediscovery/stop_words.py
+++ b/freediscovery/stop_words.py
@@ -211,3 +211,13 @@ class _StopWordsWrapper(object):
         self.name = os.path.join(self.model_dir, name + '.pkl')
         self.stop_words = load(self.name)
         return (self.stop_words)
+
+    def delete(self, name):
+        """Allow to delete the stop_words list of strings
+        """
+        self.model_dir = os.path.join(self.cache_dir, 'stop_words')
+
+        if os.path.exists(os.path.join(self.model_dir, name + '.pkl')):
+            os.remove(os.path.join(self.model_dir, name + '.pkl'))
+
+

--- a/freediscovery/tests/test_stop_words.py
+++ b/freediscovery/tests/test_stop_words.py
@@ -9,10 +9,10 @@ import os.path
 import shutil
 import pytest
 
-from unittest import SkipTest
+
 from freediscovery.stop_words import (_StopWordsWrapper)
 from .run_suite import check_cache
-from sklearn.externals.joblib import dump, load
+
 
 from freediscovery.stop_words import CUSTOM_STOP_WORDS as csw
 from freediscovery.stop_words import COMMON_FIRST_NAMES as cfns
@@ -21,29 +21,37 @@ basename = os.path.dirname(__file__)
 
 cache_dir = check_cache()
 
-tested_stop_words = ['one', 'two', 'three', 'foure', 'five', 'six']
+tested_stop_words = ['one', 'two', 'three', 'four', 'five', 'six']
 
 
 @pytest.mark.parametrize('csw_name, csw_list', [
                         ('test_acstw', tested_stop_words),
                         ('common_first_names', cfns),
+                        ('csw', csw)
                          ])
 def test_custom_stop_words_param(csw_name, csw_list):
-    """Test to save and retrive the custom stop words
+    """Test to save, retrieve and delete the custom stop words
 
        tested_stop_words - list of custom stop words,
        cfns - list of common first names imported from stop_words.py
               to use as a custom stop words in testing
     """
-    custom_sw = _StopWordsWrapper(cache_dir = cache_dir)
-    custom_sw.save(name = csw_name, stop_words = csw_list)
-    custom_stop_words = custom_sw.load(name = csw_name)
+
+    # test to save and retrieve the custom stop words
+    custom_sw = _StopWordsWrapper(cache_dir=cache_dir)
+    custom_sw.save(name=csw_name, stop_words=csw_list)
+    custom_stop_words = custom_sw.load(name=csw_name)
     assert(custom_stop_words == csw_list)
-    assert(len(custom_stop_words)==len(csw_list))
+    assert(len(custom_stop_words) == len(csw_list))
     i = 0
     for word in custom_stop_words:
         assert word == csw_list[i]
-        i+=1
+        i += 1
+
+    # test to delete the custom stop words
+    custom_sw.delete(name=csw_name)
+    with pytest.raises(FileNotFoundError):
+        custom_sw.load(name=csw_name)
 
     # clearing from temporary testing data
     if os.path.isdir(os.path.join(cache_dir, 'stop_words')):


### PR DESCRIPTION
added a `DELETE /stop-words/<name>` endpoint with corresponding unittests and schema definition.  