### PR TITLE
MNT Improve REST unit tests

### DIFF
--- a/freediscovery/server/tests/test_categorization.py
+++ b/freediscovery/server/tests/test_categorization.py
@@ -34,36 +34,30 @@ def test_api_lsi(app):
     assert res.status_code == 200
     data = parse_res(res)
     method = V01 + "/lsi/"
-    res = app.get(method,
+    res = app.get_check(method,
             data=dict(
                 parent_id=dsid,
                 )
             )
-    assert res.status_code == 200
 
     lsi_pars = dict( n_components=101, parent_id=dsid)
     method = V01 + "/lsi/"
-    res = app.post(method, json=lsi_pars)
-    assert res.status_code == 200
-    data = parse_res(res)
+    data = app.post_check(method, json=lsi_pars)
+
     assert sorted(data.keys()) == ['explained_variance', 'id']
     lid = data['id']
 
 
     # checking again that we can load all the lsi models
     method = V01 + "/lsi/"
-    res = app.get(method,
+    data = app.get_check(method,
             data=dict(
                 parent_id=dsid,
                 )
             )
-    assert res.status_code == 200
-    data = parse_res(res)  # TODO unused variable
     
     method = V01 + "/lsi/{}".format(lid)
-    res = app.get(method)
-    assert res.status_code == 200
-    data = parse_res(res)
+    data = app.get_check(method)
     for key, vals in lsi_pars.items():
         assert vals == data[key]
 
@@ -92,9 +86,7 @@ def _api_categorization_wrapper(app, solver, cv, n_categories, n_categories_trai
         parent_id = dsid
 
     method = V01 + "/feature-extraction/{}".format(dsid)
-    res = app.get(method)
-    assert res.status_code == 200
-    data = parse_res(res)
+    data = app.get_check(method)
 
     categories_list = list(set([row['category'] for row in ds_input['dataset']]))
 
@@ -114,12 +106,10 @@ def _api_categorization_wrapper(app, solver, cv, n_categories, n_categories_trai
 
     method = V01 + "/categorization/"
     try:
-        res = app.post(method, json=pars)
+        data = app.post_check(method, json=pars)
     except OptionalDependencyMissing:
         raise SkipTest
 
-    data = parse_res(res)
-    assert res.status_code == 200, method
     assert dict2type(data) == {'id' : 'str',
                                'training_scores': {'recall': 'float',
                                                     'f1': 'float',
@@ -148,16 +138,13 @@ def _api_categorization_wrapper(app, solver, cv, n_categories, n_categories_trai
     mid = data['id']
 
     method = V01 + "/categorization/{}".format(mid)
-    res = app.get(method)
-    assert res.status_code == 200
-    data = parse_res(res)
+    data = app.get_check(method)
 
     for key in ["method"]:
         assert pars[key] == data[key]
 
     method = V01 + "/categorization/{}/predict".format(mid)
-    res = app.get(method)
-    data = parse_res(res)
+    data = app.get_check(method)
     data = data['data']
     response_ref = { 'document_id': 'int',
                      'scores': [ {'category': 'str',
@@ -181,11 +168,9 @@ def _api_categorization_wrapper(app, solver, cv, n_categories, n_categories_trai
         assert_equal(np.in1d(training_document_id_res, training_document_id), True)
 
     method = V01 + "/metrics/categorization"
-    res = app.post(method,
+    data = app.post_check(method,
             json={'y_true': ds_input['dataset'],
                   'y_pred': data})
-    data = parse_res(res)
-
 
     assert dict2type(data) == {'precision': 'float',
                                'recall': 'float',
@@ -202,8 +187,7 @@ def _api_categorization_wrapper(app, solver, cv, n_categories, n_categories_trai
         assert data['f1'] > 0.32
 
     method = V01 + "/categorization/{}".format(mid)
-    res = app.delete(method)
-    assert res.status_code == 200
+    res = app.delete_check(method)
 
 
 _categoriazation_pars = itertools.product( ["LinearSVC", "LogisticRegression",

--- a/freediscovery/server/tests/test_clustering.py
+++ b/freediscovery/server/tests/test_clustering.py
@@ -41,11 +41,7 @@ def test_api_clustering(app, model, use_lsi):
         parent_id = dsid
 
     method = V01 + "/feature-extraction/{}".format(dsid)
-    res = app.get(method)
-    assert res.status_code == 200
-    data = parse_res(res)  # TODO unused variable
-
-    #if (model == 'birch' or model == "ward_hc"):
+    data = app.get_check(method)
 
     url = V01 + "/clustering/" + model
     pars = { 'parent_id': parent_id, }
@@ -53,18 +49,15 @@ def test_api_clustering(app, model, use_lsi):
         pars['n_clusters'] = 13
     if model == 'dbscan':
         pars.update({'eps': 0.1, "min_samples": 2})
-    res = app.post(url, json=pars)
+    data = app.post_check(url, json=pars)
 
-    assert res.status_code == 200
-    data = parse_res(res)
     assert sorted(data.keys()) == sorted(['id'])
     mid = data['id']
 
     url += '/{}'.format(mid)
     n_top_words = 2
-    res = app.get(url, query_string={'n_top_words': n_top_words})
-    assert res.status_code == 200
-    data = parse_res(res)
+    data = app.get_check(url, query_string={'n_top_words': n_top_words})
+
     assert dict2type(data, max_depth=1) == {'data': 'list'}
     for row in data['data']:
         assert dict2type(row, max_depth=1) == {'cluster_id': 'int',
@@ -81,5 +74,4 @@ def test_api_clustering(app, model, use_lsi):
     #    assert sorted(data['htree'].keys()) == \
     #            sorted(['n_leaves', 'n_components', 'children'])
 
-    res = app.delete(url)
-    assert res.status_code == 200
+    app.delete_check(url)

--- a/freediscovery/server/tests/test_custom_stop_words.py
+++ b/freediscovery/server/tests/test_custom_stop_words.py
@@ -31,17 +31,13 @@ def test_stop_words(app):
 
     method = V01 + "/stop-words/"
     pars = dict(name=name, stop_words=tested_stop_words)
-    res = app.post(method, json=pars)
-    assert res.status_code == 200
+    data = app.post_check(method, json=pars)
 
     method = V01 + "/stop-words/{}".format(name)
-    res = app.get(method)
-    assert res.status_code == 200
-    data = parse_res(res)
+    data = app.get_check(method)
 
     assert dict2type(data, collapse_lists=True) == {'name': 'str', 'stop_words': ['str']}
     assert data["stop_words"] == tested_stop_words
 
     method = V01 + "/stop-words/{}".format(name)
-    res = app.delete(method)
-    assert res.status_code == 200
+    app.delete_check(method)

--- a/freediscovery/server/tests/test_duplicate_detection.py
+++ b/freediscovery/server/tests/test_duplicate_detection.py
@@ -40,23 +40,17 @@ def test_api_dupdetection(app, kind, options):
     dsid, pars, _ = get_features_cached(app, hashed=False)
 
     method = V01 + "/feature-extraction/{}".format(dsid)
-    res = app.get(method)
-    assert res.status_code == 200
-    data = parse_res(res)  # TODO unused variable
+    data = app.get_check(method)
 
     url = V01 + "/duplicate-detection" 
     pars = { 'parent_id': dsid,
              'method': kind}
-    res = app.post(url, json=pars)
-    assert res.status_code == 200
-    data = parse_res(res)
+    data = app.post_check(url, json=pars)
     assert dict2type(data) == {'id': 'str'}
     mid = data['id']
 
     url += '/{}'.format(mid)
-    res = app.get(url, query_string=options)
-    assert res.status_code == 200
-    data = parse_res(res)
+    data = app.get_check(url, query_string=options)
 
     assert dict2type(data, max_depth=1) == {'data': 'list'}
     for row in data['data']:
@@ -64,5 +58,4 @@ def test_api_dupdetection(app, kind, options):
                                                'cluster_similarity': 'float',
                                                'documents': 'list'}
 
-    res = app.delete(url)
-    assert res.status_code == 200
+    app.delete_check(url)

--- a/freediscovery/server/tests/test_email_threading.py
+++ b/freediscovery/server/tests/test_email_threading.py
@@ -31,10 +31,8 @@ def parse_emails(app):
     method = V01 + "/email-parser/"
     pars = dict(data_dir=email_data_dir)
 
-    res = app.post(method, json=pars)
+    data = app.post_check(method, json=pars)
 
-    assert res.status_code == 200, method
-    data = parse_res(res)
     assert sorted(data.keys()) ==  ['filenames', 'id']
     dsid = data['id']
 
@@ -44,9 +42,7 @@ def test_parse_emails(app):
     dsid, pars = parse_emails(app)
 
     method = V01 + "/email-parser/{}".format(dsid)
-    res = app.get(method)
-    assert res.status_code == 200, method
-    data = parse_res(res)
+    data = app.get_check(method)
     for key, val in pars.items():
         if key in ['data_dir']:
             continue
@@ -57,15 +53,12 @@ def test_delete_parsed_emails(app):
     dsid, _ = parse_emails(app)
 
     method = V01 + "/email-parser/{}".format(dsid)
-    res = app.delete(method)
-    assert res.status_code == 200
+    app.delete_check(method)
 
 
 def test_get_email_parser_all(app):
     method = V01 + "/email-parser/"
-    res = app.get(method)
-    assert res.status_code == 200
-    data = parse_res(res)
+    data = app.get_check(method)
     for row in data:
         assert sorted(row.keys()) == sorted([ 'data_dir', 'id', 'encoding', 'n_samples']) 
 
@@ -73,9 +66,7 @@ def test_get_email_parser_all(app):
 def test_get_email_parser(app):
     dsid, _ = parse_emails(app)
     method = V01 + "/email-parser/{}".format(dsid)
-    res = app.get(method)
-    assert res.status_code == 200
-    data = parse_res(res)
+    data = app.get_check(method)
     assert sorted(data.keys()) == \
              sorted(['data_dir', 'filenames', 'encoding', 'n_samples', 'type'])
 
@@ -88,9 +79,7 @@ def test_get_search_emails_by_filename(app):
             ({ 'filenames': ['1', '2']}, [0, 1]),
             ({ 'filenames': ['5']}, [4])]:
 
-        res = app.post(method, json=pars)
-        assert res.status_code == 200
-        data = parse_res(res)
+        data = app.post_check(method, json=pars)
         assert sorted(data.keys()) ==  sorted(['index'])
         assert_equal(data['index'], indices)
 
@@ -108,16 +97,12 @@ def test_api_thread_emails(app):
     dsid, _ = parse_emails(app)
 
     method = V01 + "/email-parser/{}".format(dsid)
-    res = app.get(method)
-    assert res.status_code == 200
-    data = parse_res(res)  # TODO unused variable
+    data = app.get_check(method)
 
     url = V01 + "/email-threading" 
     pars = { 'parent_id': dsid }
-             
-    res = app.post(url, json=pars)
-    assert res.status_code == 200
-    data = parse_res(res)
+
+    data = app.post_check(url, json=pars)
     assert sorted(data.keys()) == sorted(['data', 'id'])
     mid = data['id']
 
@@ -141,10 +126,7 @@ def test_api_thread_emails(app):
     assert data['data'] == tree_ref
 
     url += '/{}'.format(mid)
-    res = app.get(url)
-    assert res.status_code == 200
-    data = parse_res(res)
+    data = app.get_check(url)
     assert sorted(data.keys()) == sorted(['group_by_subject'])
 
-    res = app.delete(method)
-    assert res.status_code == 200
+    app.delete_check(method)

--- a/freediscovery/server/tests/test_ingestion.py
+++ b/freediscovery/server/tests/test_ingestion.py
@@ -31,9 +31,7 @@ def test_get_features(app):
     dsid, pars, _ = get_features_cached(app)
 
     method = V01 + "/feature-extraction/{}".format(dsid)
-    res = app.get(method)
-    assert res.status_code == 200, method
-    data = parse_res(res)
+    data = app.get_check(method)
     for key, val in pars.items():
         if key in ['data_dir', 'dataset_definition']:
             continue
@@ -43,15 +41,12 @@ def test_delete_feature_extraction(app):
     dsid, _ = get_features(app)
 
     method = V01 + "/feature-extraction/{}".format(dsid)
-    res = app.delete(method)
-    assert res.status_code == 200
+    app.delete_check(method)
 
 
 def test_get_feature_extraction_all(app):
     method = V01 + "/feature-extraction/"
-    res = app.get(method)
-    assert res.status_code == 200
-    data = parse_res(res)
+    data = app.get_check(method)
     for row in data:
         del row['norm']
         assert sdict_keys(row) == sdict_keys({'analyzer': 'str',
@@ -66,9 +61,7 @@ def test_get_feature_extraction_all(app):
 def test_get_feature_extraction(app, hashed):
     dsid, _, _ = get_features_cached(app, hashed=hashed)
     method = V01 + "/feature-extraction/{}".format(dsid)
-    res = app.get(method)
-    assert res.status_code == 200
-    data = parse_res(res)
+    data = app.get_check(method)
     assert dict2type(data, collapse_lists=True) == {'analyzer': 'str',
                      'ngram_range': ['int'], 'stop_words': 'NoneType',
                      'n_jobs': 'int', 'chunk_size': 'int', 'norm': 'str',
@@ -94,9 +87,8 @@ def test_get_search_filenames(app):
 
     # Query 1
     file_path_obj  = [{'file_path': val} for val in ['00401.txt', '00506.txt']]
-    res = app.post(method, json={'data': file_path_obj})
-    assert res.status_code == 200
-    data = parse_res(res)['data']
+    data = app.post_check(method, json={'data': file_path_obj})
+    data = data['data']
 
     for idx in range(len(data)):
         assert dict2type(data[idx]) == response_ref
@@ -110,9 +102,8 @@ def test_get_search_filenames(app):
 
     # Query 2
     file_path_obj  = [{'document_id': 4 }, {'document_id': 9}]
-    res = app.post(method, json={'data': file_path_obj})
-    assert res.status_code == 200
-    data = parse_res(res)['data']
+    data = app.post_check(method, json={'data': file_path_obj})
+    data = data['data']
 
     for idx in range(len(data)):
         assert dict2type(data[idx]) == response_ref

--- a/freediscovery/server/tests/test_lsi.py
+++ b/freediscovery/server/tests/test_lsi.py
@@ -34,42 +34,35 @@ def test_api_lsi(app):
     assert res.status_code == 200
     data = parse_res(res)
     method = V01 + "/lsi/"
-    res = app.get(method,
+    res = app.get_check(method,
             data=dict(
                 parent_id=dsid,
                 )
             )
-    assert res.status_code == 200
 
     lsi_pars = dict( n_components=101, parent_id=dsid)
     method = V01 + "/lsi/"
-    res = app.post(method, json=lsi_pars)
-    assert res.status_code == 200
-    data = parse_res(res)
+    data = app.post_check(method, json=lsi_pars)
     assert sorted(data.keys()) == ['explained_variance', 'id']
     lid = data['id']
 
 
     # checking again that we can load all the lsi models
     method = V01 + "/lsi/"
-    res = app.get(method,
+    data = app.get(method,
             data=dict(
                 parent_id=dsid,
                 )
             )
-    assert res.status_code == 200
-    data = parse_res(res)  # TODO unused variable
-    
+
     method = V01 + "/lsi/{}".format(lid)
-    res = app.get(method)
-    assert res.status_code == 200
-    data = parse_res(res)
+    data = app.get_check(method)
     for key, vals in lsi_pars.items():
         assert vals == data[key]
 
     assert sorted(data.keys()) == \
             sorted(["n_components", "parent_id"])
-    
+
     for key in data.keys():
         assert data[key] == lsi_pars[key]
 

--- a/freediscovery/server/tests/test_metrics.py
+++ b/freediscovery/server/tests/test_metrics.py
@@ -39,10 +39,7 @@ def test_categorization_metrics(app, metrics):
                       enumerate([0, 0, 1, 1, 1, 0, 1, 1, 1])]
 
     pars = {'y_true': y_true, 'y_pred': y_pred, 'metrics': metrics}
-    res = app.post(url, json=pars)
-    assert res.status_code == 200
-
-    data = parse_res(res)
+    data = app.post_check(url, json=pars)
     assert sorted(data.keys()) == sorted(metrics)
     for key in metrics:
         assert data[key] > 0.5
@@ -59,10 +56,8 @@ def test_clustering_metrics(app, metrics):
     labels_pred = [0, 0, 1, 1]
 
     pars = {'labels_true': labels_true, 'labels_pred': labels_pred, 'metrics': metrics}
-    res = app.post(url, json=pars)
-    assert res.status_code == 200
+    data = app.post_check(url, json=pars)
 
-    data = parse_res(res)
     assert sorted(data.keys()) == sorted(metrics)
     if 'adjusted_rand' in metrics:
         assert_almost_equal(data['adjusted_rand'], 0.5714, decimal=4)
@@ -81,10 +76,7 @@ def test_dupdetection_metrics(app, metrics):
     labels_pred = [0, 1, 3, 2, 5, 2]
 
     pars = {'labels_true': labels_true, 'labels_pred': labels_pred, 'metrics': metrics}
-    res = app.post(url, json=pars)
-    assert res.status_code == 200
-
-    data = parse_res(res)
+    data = app.post_check(url, json=pars)
     assert sorted(data.keys()) == sorted(metrics)
     if 'ratio_duplicates' in metrics:
         assert_almost_equal(data['ratio_duplicates'], 0.5)

--- a/freediscovery/server/tests/test_search.py
+++ b/freediscovery/server/tests/test_search.py
@@ -52,9 +52,7 @@ def test_search(app, method, min_score, max_results):
         pars['max_results'] = max_results
 
 
-    res = app.post(V01 + "/search/", json=pars)
-    assert res.status_code == 200
-    data = parse_res(res)
+    data = app.post_check(V01 + "/search/", json=pars)
     assert sorted(data.keys()) == ['data']
     data = data['data']
     for row in data:
@@ -66,8 +64,7 @@ def test_search(app, method, min_score, max_results):
     if max_results is not None:
         assert len(data) == min(max_results, len(input_ds['dataset']))
 
-    res = app.post(V01 + "/feature-extraction/{}/id-mapping".format(dsid), 
+    data = app.post_check(V01 + "/feature-extraction/{}/id-mapping".format(dsid), 
                    json={'data': [data[0]]})
-    res = parse_res(res)
     if max_results is None:
-        assert res['data'][0]['file_path'] == query_file_path
+        assert data['data'][0]['file_path'] == query_file_path

--- a/freediscovery/server/tests/test_various.py
+++ b/freediscovery/server/tests/test_various.py
@@ -22,8 +22,7 @@ from .base import parse_res, V01, app, app_notest, get_features, get_features_ls
 
 
 def test_example_dataset(app):
-    res = app.get(V01 + '/example-dataset/20newsgroups_micro')
-    data = parse_res(res)
+    data = app.get_check(V01 + '/example-dataset/20newsgroups_micro')
     assert dict2type(data, max_depth=1) == {'dataset': 'list',
                                             'training_set': 'list',
                                             'metadata': 'dict'}
@@ -42,7 +41,6 @@ def test_example_dataset(app):
 
 
 def test_openapi_specs(app):
-    res = app.get('/openapi-specs.json')
-    data = parse_res(res)
+    data = app.get_check('/openapi-specs.json')
     assert data['swagger'] == '2.0'
 


### PR DESCRIPTION
This PR adds the `post_check`, `get_check`, `delete_check` methods to the flask test client, that,
  -  check that the call succeded (e.g. return code 200)
  - converts the json response to a python dict

which allows to reduce code repetitions in all the tests suite (and remove the calls to `parse_res` function). 