### PR TITLE
change temp dir to python default

### DIFF
--- a/freediscovery/tests/run_suite.py
+++ b/freediscovery/tests/run_suite.py
@@ -23,10 +23,8 @@ def run_cli(coverage=False):
 
 
 def check_cache():
-    if os.name == 'nt':
-        cache_dir = '.\\'
-    else:
-        cache_dir = "/tmp/"
+    import tempfile
+    cache_dir = tempfile.gettempdir()
 
     if not os.path.exists(cache_dir):
         raise SkipTest


### PR DESCRIPTION
I change the temp directory to the python default one. This would make the repository cleaner when running on windows environment. 
This would also work on linux since the default temp file directory is also /tmp/