### PR TITLE
Added the query_document_id parameter to semantic search

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,3 +13,6 @@ test: test3
 
 test_cov: 
 	cd ..; python3 -c "import freediscovery.tests as ft; ft.run(coverage=True)"
+
+clean:
+	find . -type d -name "__pycache__" -exec rm -fr {} \;

--- a/freediscovery/server/tests/test_search.py
+++ b/freediscovery/server/tests/test_search.py
@@ -68,3 +68,29 @@ def test_search(app, method, min_score, max_results):
                    json={'data': [data[0]]})
     if max_results is None:
         assert data['data'][0]['file_path'] == query_file_path
+
+
+def test_search_document_id(app):
+    dsid, lsi_id, _, input_ds = get_features_lsi_cached(app, hashed=False)
+    parent_id = lsi_id
+
+    max_results = 2
+    query_document_id = 3844
+
+    pars = dict(parent_id=parent_id,
+                max_results=max_results,
+                sort=True,
+                query_document_id=query_document_id)
+
+
+    data = app.post_check(V01 + "/search/", json=pars)
+    assert sorted(data.keys()) == ['data']
+    data = data['data']
+    for row in data:
+        assert dict2type(row) == {'score': 'float',
+                                  'document_id': 'int'}
+    scores = np.array([row['score'] for row in data])
+    assert_equal(np.diff(scores) <= 0, True)
+    assert len(data) == min(max_results, len(input_ds['dataset']))
+    assert data[0]['document_id'] == query_document_id
+    assert data[0]['score'] >= 0.99


### PR DESCRIPTION
This PR adds the `query_document_id` parameter to the semantic search which allows to pass a document id as search query instead of a user provided text.