### PR TITLE
MNT remove cache_dir at the end of unit tests

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -57,6 +57,7 @@ RUN python setup.py install && \
 # > At the moment, setting "LANG=C" on a Linux system *fundamentally breaks Python 3*, and that's not OK.
 # rth: not sure if this is still relevant.
 ENV LANG C.UTF-8
+ENV DOCKER 1
 
 
 CMD ["/usr/bin/supervisord", "-c", "/etc/supervisor/conf.d/supervisord.conf"]

--- a/examples/python_categorization.txt
+++ b/examples/python_categorization.txt
@@ -18,7 +18,7 @@ from freediscovery.utils import categorization_score
 
 dataset_name = "treclegal09_2k_subset"     # see list of available datasets
 
-cache_dir = check_cache()
+cache_dir = check_cache(test_env=False)
 
 if __name__ == '__main__':
 

--- a/examples/python_clustering.py_disabled
+++ b/examples/python_clustering.py_disabled
@@ -16,7 +16,7 @@ from time import time
 pd.options.display.float_format = '{:,.3f}'.format
 
 dataset_name = "treclegal09_2k_subset"
-cache_dir = check_cache()
+cache_dir = check_cache(test_env=False)
 
 
 print("0. Load Dataset")

--- a/freediscovery/externals/flask_compress.py
+++ b/freediscovery/externals/flask_compress.py
@@ -1,0 +1,124 @@
+
+# Authors: William Fagan
+# Copyright (c) 2013-2017 William Fagan
+# License: The MIT License (MIT)
+
+import sys
+from gzip import GzipFile
+from io import BytesIO
+
+from flask import request, current_app
+
+
+if sys.version_info[:2] == (2, 6):
+    class GzipFile(GzipFile):
+        """ Backport of context manager support for python 2.6"""
+        def __enter__(self):
+            if self.fileobj is None:
+                raise ValueError("I/O operation on closed GzipFile object")
+            return self
+
+        def __exit__(self, *args):
+            self.close()
+
+
+class DictCache(object):
+
+    def __init__(self):
+        self.data = {}
+
+    def get(self, key):
+        return self.data.get(key)
+
+    def set(self, key, value):
+        self.data[key] = value
+
+
+class Compress(object):
+    """
+    The Compress object allows your application to use Flask-Compress.
+
+    When initialising a Compress object you may optionally provide your
+    :class:`flask.Flask` application object if it is ready. Otherwise,
+    you may provide it later by using the :meth:`init_app` method.
+
+    :param app: optional :class:`flask.Flask` application object
+    :type app: :class:`flask.Flask` or None
+    """
+    def __init__(self, app=None):
+        """
+        An alternative way to pass your :class:`flask.Flask` application
+        object to Flask-Compress. :meth:`init_app` also takes care of some
+        default `settings`_.
+
+        :param app: the :class:`flask.Flask` application object.
+        """
+        self.app = app
+        if app is not None:
+            self.init_app(app)
+
+    def init_app(self, app):
+        defaults = [
+            ('COMPRESS_MIMETYPES', ['text/html', 'text/css', 'text/xml',
+                                    'application/json',
+                                    'application/javascript']),
+            ('COMPRESS_LEVEL', 6),
+            ('COMPRESS_MIN_SIZE', 500),
+            ('COMPRESS_CACHE_KEY', None),
+            ('COMPRESS_CACHE_BACKEND', None),
+            ('COMPRESS_REGISTER', True),
+        ]
+
+        for k, v in defaults:
+            app.config.setdefault(k, v)
+
+        backend = app.config['COMPRESS_CACHE_BACKEND']
+        self.cache = backend() if backend else None
+        self.cache_key = app.config['COMPRESS_CACHE_KEY']
+
+        if (app.config['COMPRESS_REGISTER'] and
+                app.config['COMPRESS_MIMETYPES']):
+            app.after_request(self.after_request)
+
+    def after_request(self, response):
+        app = self.app or current_app
+        accept_encoding = request.headers.get('Accept-Encoding', '')
+
+        if (response.mimetype not in app.config['COMPRESS_MIMETYPES'] or
+            'gzip' not in accept_encoding.lower() or
+            not 200 <= response.status_code < 300 or
+            (response.content_length is not None and
+             response.content_length < app.config['COMPRESS_MIN_SIZE']) or
+            'Content-Encoding' in response.headers):
+            return response
+
+        response.direct_passthrough = False
+
+        if self.cache:
+            key = self.cache_key(response)
+            gzip_content = self.cache.get(key) or self.compress(app, response)
+            self.cache.set(key, gzip_content)
+        else:
+            gzip_content = self.compress(app, response)
+
+        response.set_data(gzip_content)
+
+        response.headers['Content-Encoding'] = 'gzip'
+        response.headers['Content-Length'] = response.content_length
+
+        vary = response.headers.get('Vary')
+        if vary:
+            if 'accept-encoding' not in vary.lower():
+                response.headers['Vary'] = '{}, Accept-Encoding'.format(vary)
+        else:
+            response.headers['Vary'] = 'Accept-Encoding'
+
+        return response
+
+    def compress(self, app, response):
+        gzip_buffer = BytesIO()
+        with GzipFile(mode='wb',
+                      compresslevel=app.config['COMPRESS_LEVEL'],
+                      fileobj=gzip_buffer) as gzip_file:
+            gzip_file.write(response.get_data())
+        return gzip_buffer.getvalue()

--- a/freediscovery/externals/joblib_pool.py
+++ b/freediscovery/externals/joblib_pool.py
@@ -1,0 +1,67 @@
+# -*- coding: utf-8 -*-
+
+# Author: Olivier Grisel <olivier.grisel@ensta.org>
+# Copyright: 2012, Olivier Grisel
+# License: BSD 3 clause
+# (adapted from joblib 0.11)
+
+import os
+import tempfile
+
+from sklearn.externals.joblib.pool import SYSTEM_SHARED_MEM_FS
+
+def _get_temp_dir(pool_folder_name, temp_folder=None):
+    """Get the full path to a subfolder inside the temporary folder.
+
+    This function is originally used in joblib.pool.MemmapingPool, but
+    it could also be used in combination with joblib.Memory, provided
+    that the produced cache folders are manually cleaned to avoid
+    running out of memory.
+
+    Parameters
+    ----------
+    pool_folder_name : str
+        Sub-folder name used for the serialization of a pool instance.
+
+    temp_folder: str, optional
+        Folder to be used by the pool for memmaping large arrays
+        for sharing memory with worker processes. If None, this will try in
+        order:
+
+        - a folder pointed by the JOBLIB_TEMP_FOLDER environment
+          variable,
+        - /dev/shm if the folder exists and is writable: this is a
+          RAMdisk filesystem available by default on modern Linux
+          distributions,
+        - the default system temporary folder that can be
+          overridden with TMP, TMPDIR or TEMP environment
+          variables, typically /tmp under Unix operating systems.
+
+    Returns
+    -------
+    pool_folder : str
+       full path to the temporary folder
+    use_shared_mem : bool
+       whether the temporary folder is written to tmpfs
+    """
+    use_shared_mem = False
+    if temp_folder is None:
+        temp_folder = os.environ.get('JOBLIB_TEMP_FOLDER', None)
+    if temp_folder is None:
+        if os.path.exists(SYSTEM_SHARED_MEM_FS):
+            try:
+                temp_folder = SYSTEM_SHARED_MEM_FS
+                pool_folder = os.path.join(temp_folder, pool_folder_name)
+                if not os.path.exists(pool_folder):
+                    os.makedirs(pool_folder)
+                use_shared_mem = True
+            except IOError:
+                # Missing rights in the the /dev/shm partition,
+                # fallback to regular temp folder.
+                temp_folder = None
+    if temp_folder is None:
+        # Fallback to the default tmp folder, typically /tmp
+        temp_folder = tempfile.gettempdir()
+    temp_folder = os.path.abspath(os.path.expanduser(temp_folder))
+    pool_folder = os.path.join(temp_folder, pool_folder_name)
+    return pool_folder, use_shared_mem

--- a/freediscovery/server/app.py
+++ b/freediscovery/server/app.py
@@ -30,6 +30,13 @@ from .resources import (FeaturesApi, FeaturesApiElement,
                         )
 
 
+if os.environ.get('DOCKER', None) is not None:
+    from ..externals.flask_compress import Compress
+
+    compress = Compress()
+else:
+    compress = None
+
 #class CatchAll(Resource):
 #
 #    def get(self, url):
@@ -62,6 +69,8 @@ def fd_app(cache_dir):
           'APISPEC_SWAGGER_UI_URL': '/swagger-ui.html'})
 
     app.test_client_class = TestClient
+    if compress is not None:
+        compress.init_app(app)
 
     docs = FlaskApiSpec(app)
 

--- a/freediscovery/server/tests/base.py
+++ b/freediscovery/server/tests/base.py
@@ -72,7 +72,7 @@ def app_notest():
     client.delete_check = app_call_wrapper(client.delete)
     return client
 
-memory = Memory(cachedir=os.path.join(cache_dir, '_joblib_cache', str(os.getpid())), verbose=0)
+memory = Memory(cachedir=os.path.join(cache_dir, '_joblib_cache'), verbose=0)
 
 #=============================================================================#
 #

--- a/freediscovery/tests/run_suite.py
+++ b/freediscovery/tests/run_suite.py
@@ -3,6 +3,8 @@
 import os
 import sys
 
+from freediscovery.externals.joblib_pool import _get_temp_dir
+
 base_dir = os.path.dirname(os.path.dirname(__file__))
 
 
@@ -22,12 +24,19 @@ def run_cli(coverage=False):
     sys.exit(status)
 
 
-def check_cache():
+def check_cache(test_env=True):
     import tempfile
-    cache_dir = tempfile.gettempdir()
+
+    if test_env:
+        subfolder = 'freediscovery-cache-test-{}'.format(os.getpid())
+    else:
+        subfolder = 'freediscovery-cache'
+
+    cache_dir, _ = _get_temp_dir(subfolder)
 
     if not os.path.exists(cache_dir):
-        raise SkipTest
+        os.mkdir(cache_dir)
+
     return cache_dir
 
 if __name__ == '__main__':

--- a/freediscovery/tests/test_base.py
+++ b/freediscovery/tests/test_base.py
@@ -8,6 +8,7 @@ from __future__ import unicode_literals
 
 import os.path
 from unittest import SkipTest
+import warnings
 
 import numpy as np
 from numpy.testing import (assert_allclose, assert_equal,
@@ -38,3 +39,18 @@ def test_normalize_cachedir():
     assert _normalize_cachedir('/tmp/') == os.path.normpath('/tmp/ediscovery_cache')
     assert _normalize_cachedir('/tmp/ediscovery_cache') == os.path.normpath('/tmp/ediscovery_cache')
 
+
+@pytest.yield_fixture(autouse=True, scope='session')
+def test_suite_cleanup():
+    import shutil
+    import traceback
+    # setup
+    yield
+    # teardown - put your command here
+    cache_dir = check_cache()
+    try:
+        shutil.rmtree(cache_dir)
+        print('\nSucessfully removed cache_dir={}'.format(cache_dir))
+    except Exeption as e:
+        warnings.warn('Failed to remove cache_dir={}, \n{}'.format(
+	                       cache_dir, traceback.print_tb(e.__traceback__)))


### PR DESCRIPTION
This PR,
  * adds automatic gzip compression to REST API responses when the builtin flask Werkzeug server is used (which has a significant performance impact)
  * automatically removes the created `cache_dir` after unit tests are executed.