### PR TITLE
Additional sorting options

### DIFF
--- a/freediscovery/categorization.py
+++ b/freediscovery/categorization.py
@@ -299,7 +299,8 @@ class _CategorizerWrapper(_BaseWrapper):
 
     @staticmethod
     def to_dict(Y_pred, nn_pred, labels, id_mapping,
-                max_result_categories=1, sort=False, min_score=None):
+                max_result_categories=1, sort_by=None,
+                sort_reverse=True, min_score=None):
         """
         Create a nested dictionary result that would be returned by 
         the REST API given the categorization results
@@ -316,8 +317,10 @@ class _CategorizerWrapper(_BaseWrapper):
            the metadata mapping from freediscovery.ingestion.DocumentIndex.data
         max_result_categories : int
            the maximum number of categories in the results
-        sort : bool
-           sort by the score of the most likely class
+        sort_by : {str, None}
+           the key used for sorting
+        sort_reverse : bool
+           reverse the sort order
         min_score : {int, None}
            filter out results below a score threashold
         """
@@ -363,8 +366,11 @@ class _CategorizerWrapper(_BaseWrapper):
                     iscores.append(iiel)
             ires['scores'] = iscores
             res.append(ires)
-        if sort:
-            res = sorted(res, key=lambda x: x['scores'][0]['score'], reverse=True)
+        if sort_by:
+            valid_sort = ['score']
+            if sort_by not in valid_sort:
+                raise ValueError('sort_by={} not in {}'.format(sort_by, valid_sort))
+            res = sorted(res, key=lambda x: x['scores'][0][sort_by], reverse=sort_reverse)
         return {'data': res}
 
 

--- a/freediscovery/server/resources.py
+++ b/freediscovery/server/resources.py
@@ -37,6 +37,8 @@ from ..email_threading import _EmailThreadingWrapper
 from ..datasets import load_dataset
 from ..exceptions import WrongParameter
 from ..stop_words import _StopWordsWrapper
+from .validators import _is_in_range
+
 from .schemas import (IDSchema, FeaturesParsSchema,
                       FeaturesSchema,
                       DocumentIndexNestedSchema,
@@ -397,27 +399,32 @@ class ModelsApiPredict(Resource):
 
             **Parameters**
              - `max_result_categories` : the maximum number of categories in the results
-             - `sort` : sort by the score of the most likely class
+             - `sort_by` : if provided and not None, the field used for sorting results. Valid values are [None, 'score']
+             - `sort_order`: the sort order (if applicable), one of ['ascending', 'descending']
              - `ml_output` : type of the output in ['decision_function', 'probability'], only affects ML methods.
              - `nn_metric` : The similarity returned by nearest neighbor classifier in ['cosine', 'jaccard', 'cosine_norm', 'jaccard_norm'].
              - `min_score` : filter out results below a similarity threashold
             """))
     @use_args({'max_result_categories': wfields.Int(missing=1),
-               'sort': wfields.Boolean(missing=False),
+               'sort_by': wfields.Str(missing='score'),
+               'sort_order': wfields.Str(missing='descending',
+                                         validate=_is_in_range(['descending', 'ascending'])),
                'ml_output': wfields.Str(missing='probability'),
                'nn_metric': wfields.Str(missing='jaccard_norm'),
                'min_score': wfields.Number(missing=-1)})
     @marshal_with(CategorizationPredictSchema())
     def get(self, mid, **args):
 
-        sort = args.pop('sort')
+        sort_by = args.pop('sort_by')
+        sort_reverse = args.pop('sort_order') == 'descending'
         max_result_categories  = args.pop('max_result_categories')
         min_score = args.pop("min_score")
         cat = _CategorizerWrapper(self._cache_dir, mid=mid)
         y_res, nn_res = cat.predict(**args)
         res = _CategorizerWrapper.to_dict(y_res, nn_res, cat.le.classes_,
                                           cat.fe.db.data,
-                                          sort=sort,
+                                          sort_by=sort_by,
+                                          sort_reverse=sort_reverse,
                                           max_result_categories=max_result_categories,
                                           min_score=min_score)
         return res
@@ -940,15 +947,18 @@ class SearchApi(Resource):
             - `nn_metric` : The similarity returned by nearest neighbor classifier in ['cosine', 'jaccard', 'cosine_norm', 'jaccard_norm'].
             - `min_score` : filter out results below a similarity threashold
             - `max_results` : return only the first `max_results` documents
-            - `sort` : sort the results by score
+             - `sort_by` : if provided and not None, the field used for sorting results. Valid values are [None, 'score']
+             - `sort_order`: the sort order (if applicable), one of ['ascending', 'descending']
             """))
     @use_args({ "parent_id": wfields.Str(required=True),
                 "query": wfields.Str(),
                 "query_document_id": wfields.Int(),
                 'nn_metric': wfields.Str(missing='jaccard_norm'),
                 'min_score': wfields.Number(missing=-1),
-                'sort': wfields.Boolean(missing=True),
                 'max_results': wfields.Int(),
+                'sort_by': wfields.Str(missing='score'),
+                'sort_order': wfields.Str(missing='descending',
+                                          validate=_is_in_range(['descending', 'ascending'])),
                 })
     @marshal_with(SearchResponseSchema())
     def post(self, **args):
@@ -972,8 +982,12 @@ class SearchApi(Resource):
 
         res = model.fe.db.render_dict(scores_pd)
         res = [row for row in res if row['score'] > args['min_score']]
-        if args['sort']:
-            res = sorted(res, key=lambda row: row['score'], reverse=True)
+        sort_by = args['sort_by']
+        if sort_by:
+            if sort_by not in res[0]:
+                raise WrongParameter('sort_by={} not in []'.format(sort_by, list(res[0].keys())))
+            sort_reverse = args['sort_order'] == 'descending'
+            res = sorted(res, key=lambda row: row['score'], reverse=sort_reverse)
         if 'max_results' in args:
             res = res[:args['max_results']]
 

--- a/freediscovery/server/tests/test_categorization.py
+++ b/freediscovery/server/tests/test_categorization.py
@@ -70,7 +70,8 @@ def test_api_lsi(app):
 
 
 
-def _api_categorization_wrapper(app, solver, cv, n_categories, n_categories_train=None):
+def _api_categorization_wrapper(app, solver, cv, n_categories,
+                                n_categories_train=None, max_results=None):
 
     cv = (cv == 'cv')
 
@@ -144,7 +145,12 @@ def _api_categorization_wrapper(app, solver, cv, n_categories, n_categories_trai
         assert pars[key] == data[key]
 
     method = V01 + "/categorization/{}/predict".format(mid)
-    data = app.get_check(method)
+    if max_results:
+        json_data = {'max_results': max_results}
+    else:
+        json_data = {}
+
+    data = app.get_check(method, json=json_data)
     data = data['data']
     response_ref = { 'document_id': 'int',
                      'scores': [ {'category': 'str',
@@ -210,3 +216,6 @@ def test_api_categorization_2cat_unsupervised(app, n_categories):
 @pytest.mark.parametrize("solver", ["LogisticRegression", "NearestNeighbor"])
 def test_api_categorization_3cat(app, solver):
     _api_categorization_wrapper(app, solver, '', 3)
+
+def test_api_categorization_max_results(app):
+    _api_categorization_wrapper(app, 'LogisticRegression', '', 2, max_results=100)

--- a/freediscovery/server/tests/test_search.py
+++ b/freediscovery/server/tests/test_search.py
@@ -28,6 +28,7 @@ from .base import (parse_res, V01, app, app_notest, get_features_cached,
                                                             ('semantic', 0.5, None),
                                                             ('semantic', -1, 1000000),
                                                             ('semantic', -1, 3),
+                                                            ('semantic', -1, 0),
                                                             ])
 def test_search(app, method, min_score, max_results):
 
@@ -61,12 +62,16 @@ def test_search(app, method, min_score, max_results):
     scores = np.array([row['score'] for row in data])
     assert_equal(np.diff(scores) <= 0, True)
     assert_array_less(min_score, scores)
-    if max_results is not None:
+    if max_results:
         assert len(data) == min(max_results, len(input_ds['dataset']))
+    elif min_score > -1:
+        pass
+    else:
+        assert len(data) == 1967
 
     data = app.post_check(V01 + "/feature-extraction/{}/id-mapping".format(dsid), 
                    json={'data': [data[0]]})
-    if max_results is None:
+    if not max_results:
         assert data['data'][0]['file_path'] == query_file_path
 
 

--- a/freediscovery/server/validators.py
+++ b/freediscovery/server/validators.py
@@ -1,0 +1,11 @@
+# -*- coding: utf-8 -*-
+
+
+def _is_in_range(valid_values):
+    """
+    Validate that an element is within a given value
+    """
+
+    def f(x):
+        if x not in valid_values:
+            raise ValueError('{} not in {}'.format(x, valid_values))

--- a/freediscovery/tests/test_categorize.py
+++ b/freediscovery/tests/test_categorize.py
@@ -113,13 +113,13 @@ def test_categorization(use_lsi, method, cv):
     assert_allclose(scores['recall'], 1, rtol=0.68)
     cat.delete()
 
-@pytest.mark.parametrize('max_result_categories, sort, has_nn', [(1, '', True),
-                                                             (1, 'sort', True),
-                                                             (1, '', False),
-                                                             (2, '', True), (3, '', True)])
-def test_categorization2dict(max_result_categories, sort, has_nn):
+@pytest.mark.parametrize('max_result_categories, sort_by, has_nn',
+                                                            [(1, None, True),
+                                                             (1, 'score', True),
+                                                             (1, None, False),
+                                                             (2, None, True), (3, '', True)])
+def test_categorization2dict(max_result_categories, sort_by, has_nn):
     import json
-    sort = (sort == 'sort')
     Y_pred = np.array([[1.0, 0.0],
                        [0.6, 0.4],
                        [0.0, 1.0],
@@ -139,10 +139,10 @@ def test_categorization2dict(max_result_categories, sort, has_nn):
     res = _CategorizerWrapper.to_dict(Y_pred, D_nn,
                                      ['negative', 'positive'], id_mapping,
                                      max_result_categories=max_result_categories,
-                                     sort=sort)
+                                     sort_by=sort_by)
     assert list(res.keys()) == ['data']
     if has_nn:
-        if max_result_categories >= 2 and not sort:
+        if max_result_categories >= 2 and not sort_by:
             assert res['data'][0] == {
                                         "internal_id": 0,
                                         "document_id": 0,
@@ -161,7 +161,7 @@ def test_categorization2dict(max_result_categories, sort, has_nn):
                                             }
                                         ]
                                       }
-        elif max_result_categories == 1 and not sort:
+        elif max_result_categories == 1 and not sort_by:
             assert res['data'][0] == {
                                         "internal_id": 0,
                                         "document_id": 0,
@@ -175,7 +175,7 @@ def test_categorization2dict(max_result_categories, sort, has_nn):
                                         ]
                                       }
 
-        elif max_result_categories == 1 and sort:
+        elif max_result_categories == 1 and sort_by:
             assert res['data'][0] == {
                                         "internal_id": 4,
                                         "document_id": 16,
@@ -188,12 +188,12 @@ def test_categorization2dict(max_result_categories, sort, has_nn):
                                             }
                                         ]
                                     }
-        elif max_result_categories == 0 and not sort:
+        elif max_result_categories == 0 and not sort_by:
             assert res['data'][0]['scores'] == []
         else:
             raise NotImplementedError
     else:
-        if max_result_categories == 1 and not sort:
+        if max_result_categories == 1 and not sort_by:
             assert res['data'][0] == {
                                         "internal_id": 0,
                                         "document_id": 0,


### PR DESCRIPTION
This PR replaces the `sort=bool` parameter in semantic search and categorization by,
  - `sort_by` in ['scores', None]
  - `sort_order` in ['ascending', 'descending']
it also ensures that `max_results <= 0` returns all the results.