### PR TITLE
Performance optimization and pagination in search

### DIFF
--- a/doc/user_manual/scaling_benchmarks.rst
+++ b/doc/user_manual/scaling_benchmarks.rst
@@ -5,7 +5,34 @@ This page aims to summarize the performance and scaling of the algorithms used i
 
 Benchmarks are computed running the `examples <./examples/index.html>`_ on the TREC 2009 corpus of 700 000 documents (1.5 GB or 7 GB uncompressed). The following benchmarks are given for Intel(R) Xeon(R) CPU E3-1225 V2 @ 3.20GHz (4 CPU cores) server with 16 GB of RAM. The time complexites are experimentally (approximately) estimated for the given parameters.
 
+Document ingestion
+------------------
 
++--------------+---------------------------+-----------+---------------------------------+
+| Method       | Parameters                | Time (s)  | Complexity                      |
++==============+===========================+===========+=================================+
+| Vectorizer   | - `use_hashing=False`     |  780      | `O(n_samples)`                  |
+|              | - `use_idf=False`         |           |                                 |
++--------------+---------------------------+-----------+---------------------------------+
+
+
+Preprocessing
+-------------
+
++--------------+---------------------------+-----------+---------------------------------+
+| Method       | Parameters                | Time (s)  | Complexity                      |
++==============+===========================+===========+=================================+
+| LSI          | - `n_components=150`      |  270      | `O(n_samples)`                  |
++--------------+---------------------------+-----------+---------------------------------+
+
+Semantic search
+---------------
+
++-------------------------+---------------------------+-----------+---------------------------------+
+| Method                  | Parameters                | Time (s)  | Complexity                      |
++=========================+===========================+===========+=================================+
+| Text query              | - `n_components=150`      |  270      | `O(n_samples)`                  |
++-------------------------+---------------------------+-----------+---------------------------------+
 
 Near Duplicates Detection
 -------------------------

--- a/freediscovery/ingestion.py
+++ b/freediscovery/ingestion.py
@@ -173,23 +173,21 @@ class DocumentIndex(object):
         else:
             base_keys = list(self.data.columns)
         if res is not None:
-            res_keys = [key for key in res if key not in base_keys]
+            res_keys = [key for key in res if key not in base_keys or key == 'internal_id']
             if not return_file_path and 'file_path' in res_keys:
                 res_keys.remove('file_path')
 
         db = db[base_keys]
 
-        out = []
+
+        db_dict = db.to_dict(orient='records')
         if res is not None:
-            for index, row in res[res_keys].iterrows():
-                row_dict = row.to_dict()
-                db_sel = db.loc[index]
-                row_dict.update(db_sel.to_dict())
-                out.append(row_dict)
+            out = res[res_keys].to_dict(orient='records')
+            for idx, row in enumerate(out):
+                internal_id = int(row['internal_id'])
+                row.update(db_dict[internal_id])
         else:
-            for index, row in db.iterrows():
-                row_dict = row.to_dict()
-                out.append(row_dict)
+            out = db_dict
 
         return out
 

--- a/freediscovery/search.py
+++ b/freediscovery/search.py
@@ -47,9 +47,12 @@ class _SearchWrapper(_BaseWrapper):
         metric : str
           the output metric to use
         """
+        if internal_id is not None:
+            vect = None
+        else:
+            vect = self.fe._load_model()
+            vect.set_params(input='content')
 
-        vect = self.fe._load_model()
-        vect.set_params(input='content')
 
         X = self.pipeline.data
 
@@ -60,6 +63,7 @@ class _SearchWrapper(_BaseWrapper):
         else:
             lsi = None
 
+
         s = Search(vect, lsi)
         s.fit(X)
 
@@ -67,6 +71,7 @@ class _SearchWrapper(_BaseWrapper):
             dist = s.search_id(internal_id, metric=metric)
         else:
             dist = s.search(text, metric=metric)
+
         return dist
 
 

--- a/freediscovery/search.py
+++ b/freediscovery/search.py
@@ -32,7 +32,7 @@ class _SearchWrapper(_BaseWrapper):
 
         super(_SearchWrapper, self).__init__(cache_dir=cache_dir,
                                           parent_id=parent_id,
-                                          mid=mid, load_model=True)
+                                          mid=mid)
 
     def search(self, text, internal_id=None, metric='cosine'):
         """

--- a/freediscovery/server/resources.py
+++ b/freediscovery/server/resources.py
@@ -947,9 +947,7 @@ class SearchApi(Resource):
                 })
     @marshal_with(SearchResponseSchema())
     def post(self, **args):
-        from time import time
         parent_id = args['parent_id']
-        t0 = time()
         model = _SearchWrapper(cache_dir=self._cache_dir, parent_id=parent_id)
 
         if 'query' in args and 'query_document_id' not in args:
@@ -975,15 +973,10 @@ class SearchApi(Resource):
             is_ascending = args['sort_order'] == 'ascending'
             scores_pd.sort_values(by=sort_by, inplace=True, ascending=is_ascending)
 
-        print(scores_pd.size)
-        print(time() - t0)
-
-        t0 = time()
-        res = model.fe.db.render_dict(scores_pd)
-        res = [row for row in res if row['score'] > args['min_score']]
         if 'max_results' in args and args['max_results'] > 0:
-            res = res[:args['max_results']]
-        print(time() - t0)
+            scores_pd = scores_pd.iloc[:args['max_results'], :]
+
+        res = model.fe.db.render_dict(scores_pd)
 
         return {'data': res}
 

--- a/freediscovery/server/resources.py
+++ b/freediscovery/server/resources.py
@@ -934,6 +934,8 @@ class SearchApi(Resource):
             - `max_results` : return only the first `max_results` documents. If `max_results <= 0` all documents are returned.
             - `sort_by` : if provided and not None, the field used for sorting results. Valid values are [None, 'score']
             - `sort_order`: the sort order (if applicable), one of ['ascending', 'descending']
+            - `batch_id`: retrieve a given subset of scores. Default: -1 (retrieves all scrores)
+            - `batch_size`: the number of document scores retrieved per batch. Default: 5000
             """))
     @use_args({ "parent_id": wfields.Str(required=True),
                 "query": wfields.Str(),
@@ -944,6 +946,8 @@ class SearchApi(Resource):
                 'sort_by': wfields.Str(missing='score'),
                 'sort_order': wfields.Str(missing='descending',
                                           validate=_is_in_range(['descending', 'ascending'])),
+                'batch_id': wfields.Int(missing=-1),
+                'batch_size': wfields.Int(missing=5000),
                 })
     @marshal_with(SearchResponseSchema())
     def post(self, **args):
@@ -957,45 +961,74 @@ class SearchApi(Resource):
             query = pd.DataFrame([{'document_id': args['query_document_id']}])
             res_q = model.fe.db.search(query, drop=False)
 
-            scores = model.search(None, internal_id=res_q.internal_id.values[0],
+            scores = model.search(None,
+                                  internal_id=res_q.internal_id.values[0],
                                   metric=args['nn_metric'])
         else:
-            raise WrongParameter("One of the 'query', 'query_document_id' must be provided")
+            raise WrongParameter("One of the 'query', "
+                                 "'query_document_id' must be provided")
 
         scores_pd = pd.DataFrame({'score': scores,
-                                  'internal_id': np.arange(model.fe.n_samples_, dtype='int')})
+                                  'internal_id': np.arange(
+                                       model.fe.n_samples_, dtype='int')})
         scores_pd = scores_pd[scores_pd.score > args['min_score']]
+
+        if 'query' not in args and 'query_document_id' in args:
+            # remove the query document
+            scores_pd = scores_pd[scores_pd.internal_id != res_q.internal_id.values[0]]
 
         sort_by = args['sort_by']
         if sort_by:
             if sort_by not in scores_pd.columns:
-                raise WrongParameter('sort_by={} not in {}'.format(sort_by, list(scores_pd.columns)))
+                raise WrongParameter(
+                    'sort_by={} not in {}'.format(sort_by,
+                                                  list(scores_pd.columns)))
             is_ascending = args['sort_order'] == 'ascending'
-            scores_pd.sort_values(by=sort_by, inplace=True, ascending=is_ascending)
+            scores_pd.sort_values(by=sort_by, inplace=True,
+                                  ascending=is_ascending)
 
         if 'max_results' in args and args['max_results'] > 0:
             scores_pd = scores_pd.iloc[:args['max_results'], :]
 
-        res = model.fe.db.render_dict(scores_pd)
+        # make the pagination happen
+        n_samples = scores_pd.shape[0]
+        batch_id = args['batch_id']
+        batch_size = args['batch_size']
+        if batch_id >= 0:
+            mslice = slice(batch_id*batch_size,
+                           min((batch_id + 1)*batch_size, n_samples))
+            scores_batch = scores_pd.iloc[mslice, :]
+        else:
+            scores_batch = scores_pd
 
-        return {'data': res}
+        res = model.fe.db.render_dict(scores_batch)
+
+        pagination = {'batch_id': args['batch_id'],
+                      'current_response_count': scores_batch.shape[0],
+                      'total_response_count': n_samples}
+        if args['batch_id'] < 0:
+            pagination['batch_id_last'] = args['batch_id']
+        else:
+            pagination['batch_id_last'] = n_samples // batch_size
+
+        return {'data': res, 'pagination': pagination}
 
 
-# ============================================================================ #
+# =========================================================================== #
 #                            Custom Stop Words
-# ============================================================================ #
+# =========================================================================== #
 
 
 class CustomStopWordsApi(Resource):
     @doc(description="Store a list of custom stop words")
-    @use_args({"name" : wfields.Str(required=True),
-               "stop_words" : wfields.List(wfields.Str(), required=True)})
+    @use_args({"name": wfields.Str(required=True),
+               "stop_words": wfields.List(wfields.Str(), required=True)})
     @marshal_with(CustomStopWordsSchema())
     def post(self, **args):
         name = args['name']
         stop_words = args['stop_words']
         model = _StopWordsWrapper(cache_dir=self._cache_dir)
-        model.save(name = name, stop_words = stop_words)
+        model.save(name=name, stop_words=stop_words)
         return {'name': name}
 
 

--- a/freediscovery/server/schemas.py
+++ b/freediscovery/server/schemas.py
@@ -199,9 +199,20 @@ class MetricsDupDetectionSchema(Schema):
 class _SearchResponseSchemaElement(DocumentIndexSchema):
     score = fields.Number(required=True)
 
+
+class _ResponsePaginaton(Schema):
+    total_response_count = fields.Int()
+    current_response_count = fields.Int()
+    batch_id = fields.Int()
+    batch_id_last = fields.Int()
+
+
 class SearchResponseSchema(Schema):
-    data = fields.Nested(_SearchResponseSchemaElement, many=True, required=True)
-    
+    data = fields.Nested(_SearchResponseSchemaElement,
+                         many=True, required=True)
+    pagination = fields.Nested(_ResponsePaginaton, required=True)
+
+
 class CustomStopWordsSchema(Schema):
     name = fields.Str(required=True)
     stop_words = fields.List(fields.Str(), required=True)

--- a/freediscovery/server/tests/test_search.py
+++ b/freediscovery/server/tests/test_search.py
@@ -52,7 +52,7 @@ def test_search(app, method, min_score, max_results):
         pars['max_results'] = max_results
 
     data = app.post_check(V01 + "/search/", json=pars)
-    assert sorted(data.keys()) == ['data']
+    assert sorted(data.keys()) == ['data', 'pagination']
     data = data['data']
     for row in data:
         assert dict2type(row) == {'score': 'float',
@@ -139,7 +139,7 @@ def test_search_document_id(app):
                 query_document_id=query_document_id)
 
     data = app.post_check(V01 + "/search/", json=pars)
-    assert sorted(data.keys()) == ['data']
+    assert sorted(data.keys()) == ['data', 'pagination']
     data = data['data']
     for row in data:
         assert dict2type(row) == {'score': 'float',
@@ -148,4 +148,4 @@ def test_search_document_id(app):
     assert_equal(np.diff(scores) <= 0, True)
     assert len(data) == min(max_results, len(input_ds['dataset']))
     # assert data[0]['document_id'] == query_document_id
-    assert data[0]['score'] >= 0.99
+    # assert data[0]['score'] >= 0.99

--- a/freediscovery/server/tests/test_search.py
+++ b/freediscovery/server/tests/test_search.py
@@ -8,7 +8,6 @@ from __future__ import unicode_literals
 import os
 import pytest
 import json
-import itertools
 from unittest import SkipTest
 import numpy as np
 from numpy.testing import assert_equal, assert_array_less
@@ -23,13 +22,13 @@ from .base import (parse_res, V01, app, app_notest, get_features_cached,
                    get_features_lsi, get_features_lsi_cached)
 
 
-@pytest.mark.parametrize("method, min_score, max_results", [('regular', -1, None),
-                                                            ('semantic', -1, None),
-                                                            ('semantic', 0.5, None),
-                                                            ('semantic', -1, 1000000),
-                                                            ('semantic', -1, 3),
-                                                            ('semantic', -1, 0),
-                                                            ])
+@pytest.mark.parametrize("method, min_score, max_results",
+                         [('regular', -1, None),
+                          ('semantic', -1, None),
+                          ('semantic', 0.5, None),
+                          ('semantic', -1, 1000000),
+                          ('semantic', -1, 3),
+                          ('semantic', -1, 0)])
 def test_search(app, method, min_score, max_results):
 
     if method == 'semantic':
@@ -52,7 +51,6 @@ def test_search(app, method, min_score, max_results):
     if max_results is not None:
         pars['max_results'] = max_results
 
-
     data = app.post_check(V01 + "/search/", json=pars)
     assert sorted(data.keys()) == ['data']
     data = data['data']
@@ -69,11 +67,63 @@ def test_search(app, method, min_score, max_results):
     else:
         assert len(data) == 1967
 
-    data = app.post_check(V01 + "/feature-extraction/{}/id-mapping".format(dsid), 
-                   json={'data': [data[0]]})
+    data = app.post_check(V01 + "/feature-extraction/{}/id-mapping"
+                          .format(dsid), 
+                          json={'data': [data[0]]})
 
     if not max_results:
         assert data['data'][0]['file_path'] == query_file_path
+
+
+def test_search_retrieve_batch(app):
+    dsid, lsi_id, _, input_ds = get_features_lsi_cached(app, hashed=False)
+    parent_id = lsi_id
+
+    max_results = -1
+    query_document_id = 3844
+    total_document_number = 1967 - 1  # removing the query one
+
+    for batch_id, batch_size in [(-1, 1000),
+                                 (0, 983),
+                                 (1, 983),
+                                 (2, 983),
+                                 (1, 1000)]:
+
+        pars = dict(parent_id=parent_id,
+                    max_results=max_results,
+                    sort=True,
+                    query_document_id=query_document_id,
+                    batch_id=batch_id,
+                    batch_size=batch_size)
+
+        data = app.post_check(V01 + "/search/", json=pars)
+        assert sorted(data.keys()) == ['data', 'pagination']
+        for row in data['data']:
+            assert dict2type(row) == {'score': 'float',
+                                      'document_id': 'int'}
+        assert dict2type(data['pagination']) == {
+                                  'total_response_count': 'int',
+                                  'current_response_count': 'int',
+                                  'batch_id': 'int',
+                                  'batch_id_last': 'int'}
+        scores = np.array([row['score'] for row in data['data']])
+        assert_equal(np.diff(scores) <= 0, True)
+        if batch_id <= 0:
+            print(data['data'][0])
+        assert len(data['data']) == data['pagination']['current_response_count']
+        assert data['pagination']['total_response_count'] == total_document_number
+        assert data['pagination']['batch_id'] == batch_id
+        if batch_id == -1:
+            assert len(data['data']) == total_document_number
+            assert data['pagination']['batch_id_last'] == batch_id
+        elif batch_id >= 0:
+            assert data['pagination']['current_response_count'] <= batch_size
+            if batch_id == 1 and batch_size == 983:
+                assert data['pagination']['current_response_count'] == batch_size
+            elif batch_id == 2:
+                assert data['pagination']['current_response_count'] == 0
+
+
 
 
 def test_search_document_id(app):
@@ -88,7 +138,6 @@ def test_search_document_id(app):
                 sort=True,
                 query_document_id=query_document_id)
 
-
     data = app.post_check(V01 + "/search/", json=pars)
     assert sorted(data.keys()) == ['data']
     data = data['data']
@@ -98,5 +147,5 @@ def test_search_document_id(app):
     scores = np.array([row['score'] for row in data])
     assert_equal(np.diff(scores) <= 0, True)
     assert len(data) == min(max_results, len(input_ds['dataset']))
-    assert data[0]['document_id'] == query_document_id
+    # assert data[0]['document_id'] == query_document_id
     assert data[0]['score'] >= 0.99

--- a/freediscovery/server/tests/test_search.py
+++ b/freediscovery/server/tests/test_search.py
@@ -71,6 +71,7 @@ def test_search(app, method, min_score, max_results):
 
     data = app.post_check(V01 + "/feature-extraction/{}/id-mapping".format(dsid), 
                    json={'data': [data[0]]})
+
     if not max_results:
         assert data['data'][0]['file_path'] == query_file_path
 

--- a/freediscovery/text.py
+++ b/freediscovery/text.py
@@ -141,7 +141,6 @@ class _BaseTextTransformer(object):
             raise ValueError('Vectorizer model id {} ({}) not found in the cache {}!'.format(
                              mid, mid_dir))
         fname = os.path.join(mid_dir, 'vectorizer')
-        print(self._pars['use_hashing'])
         if self._pars['use_hashing']:
             cmod = joblib.load(fname)
         else:

--- a/freediscovery/text.py
+++ b/freediscovery/text.py
@@ -40,12 +40,13 @@ def _vectorize_chunk(dsid_dir, k, pars, pretend=False):
     mslice = slice(k*chunk_size, min((k+1)*chunk_size, n_samples))
 
     if pars['use_idf']:
-        pars['binary'] = False # need to apply TFIDF weights first 
+        pars['binary'] = False  # need to apply TFIDF weights first
 
-    hash_opts = {key: vals for key, vals in pars.items() \
-            if key in ['stop_words', 'n_features', 'binary', 'analyser', 'ngram_range']}
+    hash_opts = {key: vals for key, vals in pars.items()
+                 if key in ['stop_words', 'n_features',
+                            'binary', 'analyser', 'ngram_range']}
     fe = HashingVectorizer(input='filename', norm=None, decode_error='ignore',
-           non_negative=True, **hash_opts) 
+                           non_negative=True, **hash_opts)
     if pretend:
         return fe
     fset_new = fe.transform(filenames[mslice])
@@ -70,7 +71,6 @@ class _BaseTextTransformer(object):
     def __init__(self, cache_dir='/tmp/', dsid=None, verbose=False):
         self.data_dir = None
         self.verbose = verbose
-
 
         self.cache_dir = cache_dir = PipelineFinder._normalize_cachedir(cache_dir)
         if not os.path.exists(cache_dir):

--- a/freediscovery/text.py
+++ b/freediscovery/text.py
@@ -8,6 +8,7 @@ import os.path
 import re
 import shutil
 import numpy as np
+import pickle
 
 from sklearn.externals import joblib
 from sklearn.externals.joblib import Parallel, delayed
@@ -139,7 +140,15 @@ class _BaseTextTransformer(object):
         if not os.path.exists(mid_dir):
             raise ValueError('Vectorizer model id {} ({}) not found in the cache {}!'.format(
                              mid, mid_dir))
-        cmod = joblib.load(os.path.join(mid_dir, 'vectorizer'))
+        fname = os.path.join(mid_dir, 'vectorizer')
+        print(self._pars['use_hashing'])
+        if self._pars['use_hashing']:
+            cmod = joblib.load(fname)
+        else:
+            # this is much faster in python 3 as cpickle is used
+            # (only works if no numpy arrays are used)
+            with open(fname, 'rb') as fh:
+                cmod = pickle.load(fh)
         return cmod
 
 
@@ -405,7 +414,13 @@ class FeatureVectorizer(_BaseTextTransformer):
                             decode_error='ignore', **opts_tfidf)
                 res = tfidf.fit_transform(pars['filenames_abs'])
                 self.vect = tfidf
-            joblib.dump(self.vect, os.path.join(dsid_dir, 'vectorizer'))
+            fname = os.path.join(dsid_dir, 'vectorizer')
+            if self._pars['use_hashing']:
+                joblib.dump(self.vect, fname)
+            else:
+                # faster for pure python objects
+                with open(fname, 'wb') as fh:
+                    pickle.dump(self.vect, fh)
 
             if pars['norm'] is not None:
                 res = normalize(res, norm=pars['norm'], copy=False)


### PR DESCRIPTION
This PR optimises semantic search and adds a pagination ability. Previously search in a 700k document collection took 180 s; this update decreases this number to,
  - 50 s if the scores of all document are returned
  - 15 s if only the first page of results is returned 