### PR TITLE
Additional tests for semantic search / categorization

### DIFF
--- a/freediscovery/categorization.py
+++ b/freediscovery/categorization.py
@@ -196,6 +196,10 @@ class _CategorizerWrapper(_BaseWrapper):
         if cv not in [None, 'fast', 'full']:
             raise WrongParameter('cv')
 
+        if method in ['NearestCentroid', 'NearestNeighbor']:
+            #print(self.pipeline[-1])
+            pass
+
         d_all = self.pipeline.data
 
         X_train = d_all[index, :]
@@ -213,7 +217,6 @@ class _CategorizerWrapper(_BaseWrapper):
             cmod.fit(X_train, Y_train, eval_metric='auc')
         else:
             cmod.fit(X_train, Y_train)
-
 
 
         joblib.dump(self.le, os.path.join(mid_dir, 'label_encoder'))
@@ -294,7 +297,7 @@ class _CategorizerWrapper(_BaseWrapper):
             else:
                 res_p = res
                 res_n = 1 - res
-            res = np.hstack((res_n[:,None], res_p[:, None]))
+            res = np.hstack((res_n[:, None], res_p[:, None]))
         return res, nn_ind
 
     def _load_pars(self, mid=None):

--- a/freediscovery/categorization.py
+++ b/freediscovery/categorization.py
@@ -233,7 +233,7 @@ class _CategorizerWrapper(_BaseWrapper):
         self.cmod = cmod
         return cmod, Y_train
 
-    def predict(self, chunk_size=5000, ml_output='probability', nn_metric='cosine'):
+    def predict(self, chunk_size=5000, ml_output='probability', metric='cosine'):
         """
         Predict the relevance using a previously trained model
 
@@ -243,7 +243,7 @@ class _CategorizerWrapper(_BaseWrapper):
            chunk size
         ml_output : str
            type of the output in ['decision_function', 'probability'], only affects ML methods. default: 'probability'
-        nn_metric : str   
+        metric : str   
             The similarity returned by nearest neighbor classifier in ['cosine', 'jaccard', 'cosine_norm', 'jaccard_norm']. default: 'cosine'
 
         Returns
@@ -270,7 +270,7 @@ class _CategorizerWrapper(_BaseWrapper):
         nn_ind = None
         if isinstance(cmod, NearestNeighborRanker):
             res, nn_ind_orig = cmod.kneighbors(ds)
-            res = _scale_cosine_similarity(res, metric=nn_metric)
+            res = _scale_cosine_similarity(res, metric=metric)
             nn_ind = self._pars['index'][nn_ind_orig]
         elif hasattr(cmod, ml_output):
             res = getattr(cmod, ml_output)(ds)

--- a/freediscovery/categorization.py
+++ b/freediscovery/categorization.py
@@ -196,9 +196,12 @@ class _CategorizerWrapper(_BaseWrapper):
         if cv not in [None, 'fast', 'full']:
             raise WrongParameter('cv')
 
-        if method in ['NearestCentroid', 'NearestNeighbor']:
-            #print(self.pipeline[-1])
-            pass
+        if method in ['NearestCentroid', 'NearestNeighbor'] \
+                and 'lsi' not in self.pipeline:
+            raise WrongParameter(method +
+                                 ' should not be applied onto raw document term vectors due'
+                                 ' to the curse of dimensionality. Please add an LSI processing'
+                                 ' step before this classifier (i.e. use `parent_id=lsi_id`)')
 
         d_all = self.pipeline.data
 

--- a/freediscovery/datasets.py
+++ b/freediscovery/datasets.py
@@ -121,7 +121,7 @@ def load_dataset(name='20newsgroups_3categories', cache_dir='/tmp',
        The ground truth files for categorization are adapted from TAR Toolkit.
 
     2. Fedora mailing list (2009-2009)
-       - `fedora_ml`
+       - `fedora_ml_3k_subset`
 
     3. The 20 newsgoups dataset
        - `20newsgroups_3categories`: only the ['comp.graphics', 'rec.sport.baseball', 'sci.space'] categories

--- a/freediscovery/pipeline.py
+++ b/freediscovery/pipeline.py
@@ -49,9 +49,6 @@ class PipelineFinder(OrderedDict):
       a unique model id
     cache_dir : str
       folder where models are saved
-    ingestion_method : str, default='vectorizer'
-      default ingestion method (one of ['vectorizer', 'parser'])
-      unless email threading is used, this whould be set to 'vectorizer'
 
     Returns
     -------
@@ -60,8 +57,7 @@ class PipelineFinder(OrderedDict):
       and as values the model ids
     """
 
-    def __init__(self, mid=None, cache_dir="/tmp/", ingestion_method='vectorizer', steps=None):
-        self.ingestion_method = ingestion_method
+    def __init__(self, mid=None, cache_dir="/tmp/", steps=None):
         self._loaded_models = {}
 
         self.mid = mid
@@ -82,9 +78,8 @@ class PipelineFinder(OrderedDict):
             cache_dir = os.path.join(cache_dir, "ediscovery_cache")
         return cache_dir
 
-
     @classmethod
-    def by_id(cls, mid, cache_dir="/tmp/", ingestion_method='vectorizer'):
+    def by_id(cls, mid, cache_dir="/tmp/"):
         """ Find a pipeline by id
 
         Parameters
@@ -93,9 +88,6 @@ class PipelineFinder(OrderedDict):
           a unique model id
         cache_dir : str
           folder where models are saved
-        ingestion_method : str, default='vectorizer'
-          default ingestion method (one of ['vectorizer', 'parser'])
-          unless email threading is used, this whould be set to 'vectorizer'
 
         Returns
         -------
@@ -105,8 +97,7 @@ class PipelineFinder(OrderedDict):
         """
         cache_dir = cls._normalize_cachedir(cache_dir)
 
-        pipeline = cls(mid=mid, cache_dir=cache_dir,
-                       ingestion_method=ingestion_method)
+        pipeline = cls(mid=mid, cache_dir=cache_dir)
 
         cache_dir_base = os.path.dirname(cache_dir)
         _break_flag = False
@@ -132,7 +123,7 @@ class PipelineFinder(OrderedDict):
             raise ModelNotFound('Model id {} not found in {}!'.format(mid, cache_dir))
 
         if path_hierarchy[0] == 'ediscovery_cache':
-            path_hierarchy[0] = ingestion_method
+            path_hierarchy[0] = 'vectorizer'
         else:
             raise ValueError('path_hierarchy should start with ediscovery_cache',
                              'this indicates a bug in the code')
@@ -159,9 +150,7 @@ class PipelineFinder(OrderedDict):
         steps.popitem(last=True)
 
         return PipelineFinder(mid=list(steps.values())[-1],
-                              cache_dir=self.cache_dir,
-                              ingestion_method=self.ingestion_method,
-                              steps=steps)
+                              cache_dir=self.cache_dir, steps=steps)
 
     @property
     def data(self):
@@ -174,9 +163,6 @@ class PipelineFinder(OrderedDict):
         elif last_node == 'lsi':
             full_path = os.path.join(ds_path, 'data')
         return joblib.load(full_path)
-
-
-
 
     def get_path(self, mid=None, absolute=True):
         """ Find the path to the model specified by mid """
@@ -192,7 +178,7 @@ class PipelineFinder(OrderedDict):
         path = list(itertools.chain.from_iterable(
                             [[key, self[key]] for key in valid_keys]))
         if absolute:
-            del path[0] # "ediscovery_cache" is already present in cache_dir
+            del path[0]  # "ediscovery_cache" is already present in cache_dir
             rel_path = os.path.join(*path)
             return os.path.join(self.cache_dir, rel_path)
         else:

--- a/freediscovery/search.py
+++ b/freediscovery/search.py
@@ -11,6 +11,7 @@ from sklearn.metrics import pairwise_distances
 from sklearn.externals import joblib
 
 from .base import _BaseWrapper
+from .exceptions import WrongParameter
 
 
 class _SearchWrapper(_BaseWrapper):
@@ -50,6 +51,13 @@ class _SearchWrapper(_BaseWrapper):
           the output metric to use
         """
         if internal_id is not None:
+            if 'lsi' not in self.pipeline:
+                raise WrongParameter('Search using a document_id as a query'
+                                     ' should not be applied in the space of '
+                                     ' raw document term vectors due'
+                                     ' to the curse of dimensionality.'
+                                     ' Please add an LSI processing'
+                                     ' step (i.e. use `parent_id=lsi_id`)')
             vect = None
         else:
             vect = self.fe.vect_

--- a/freediscovery/server/resources.py
+++ b/freediscovery/server/resources.py
@@ -126,7 +126,7 @@ class FeaturesApi(Resource):
              - `chuck_size`: The number of documents simultaneously processed by a running job (default: 5000)
              - `binary`: If set to 1, all non zero counts are set to 1. (default: False)
              - `use_idf`: Enable inverse-document-frequency reweighting (default: False).
-             - `sublinear_tf`: Apply sublinear tf scaling, i.e. replace tf with log(1 + tf) (default: False).
+             - `sublinear_tf`: Apply sublinear tf scaling, i.e. replace tf with log(1 + tf) (default: True).
              - `use_hashing`: Enable hashing. This option must be set to True for classification and set to False for clustering. (default: True)
              - `min_df`: When building the vocabulary ignore terms that have a document frequency strictly lower than the given threshold. This value is ignored when hashing is used.
              - `max_df`: When building the vocabulary ignore terms that have a document frequency strictly higher than the given threshold. This value is ignored when hashing is used.
@@ -363,7 +363,7 @@ class ModelsApiPredict(Resource):
                                                                 'ascending'])),
                'max_results': wfields.Int(),
                'ml_output': wfields.Str(missing='probability'),
-               'metric': wfields.Str(missing='jaccard_norm'),
+               'metric': wfields.Str(missing='cosine'),
                'min_score': wfields.Number(missing=-1),
                'subset': wfields.Str(missing='test',
                                      validate=_is_in_range(['all', 'train',
@@ -518,8 +518,8 @@ class BirchClusteringApi(Resource):
             'n_clusters': wfields.Int(missing=-1),
             'branching_factor': wfields.Int(missing=20),
             # this corresponds approximately to threashold = 0.5
-            'min_similarity': wfields.Number(missing=0.75),
-            'metric': wfields.Str(missing='jaccard_norm')
+            'min_similarity': wfields.Number(missing=0.5),
+            'metric': wfields.Str(missing='cosine')
             }
             )
     @marshal_with(IDSchema())
@@ -558,7 +558,7 @@ class DBSCANClusteringApi(Resource):
     @use_args({'parent_id': wfields.Str(required=True),
                'min_samples': wfields.Int(missing=10),
                # this corresponds approximately to threashold = 0.5
-               'min_similarity': wfields.Number(missing=0.75),
+               'min_similarity': wfields.Number(missing=0.5),
                'metric': wfields.Str(missing='jaccard_norm')})
     @marshal_with(IDSchema())
     def post(self, **args):
@@ -589,7 +589,7 @@ class ClusteringApiElement(Resource):
             - `sampling_min_coverage` : Minimal coverage requirement in [0, 1] range. Increasing this value would result in a larger number of samples. (default: 0.9)
             """))
     @use_args({'n_top_words': wfields.Int(missing=5),
-               'metric': wfields.Str(missing='jaccard_norm'),
+               'metric': wfields.Str(missing='cosine'),
                'return_optimal_sampling': wfields.Bool(missing=False),
                'sampling_min_similarity': wfields.Number(missing=1.0),
                'sampling_min_coverage': wfields.Number(missing=0.9)})
@@ -740,7 +740,7 @@ class DupDetectionApiElement(Resource):
     @use_args({'distance': wfields.Int(),
                'n_rand_lexicons': wfields.Int(),
                'rand_lexicon_ratio': wfields.Number(),
-               'metric': wfields.Str(missing='jaccard_norm')
+               'metric': wfields.Str(missing='cosine')
                })
     @marshal_with(ClusteringSchema())
     def get(self, mid, **args):
@@ -1021,7 +1021,7 @@ class SearchApi(Resource):
     @use_args({"parent_id": wfields.Str(required=True),
                "query": wfields.Str(),
                "query_document_id": wfields.Int(),
-               'metric': wfields.Str(missing='jaccard_norm'),
+               'metric': wfields.Str(missing='cosine'),
                'min_score': wfields.Number(missing=-1),
                'max_results': wfields.Int(),
                'sort_by': wfields.Str(missing='score'),

--- a/freediscovery/server/tests/test_categorization.py
+++ b/freediscovery/server/tests/test_categorization.py
@@ -28,7 +28,7 @@ from .base import (parse_res, V01, app, app_notest, get_features, get_features_l
 #=============================================================================#
 
 def test_api_lsi(app):
-    dsid, _ = get_features(app)
+    dsid, pars, _ = get_features_cached(app)
     method = V01 + "/feature-extraction/{}".format(dsid)
     res = app.get(method)
     assert res.status_code == 200
@@ -60,15 +60,12 @@ def test_api_lsi(app):
 def _api_categorization_wrapper(app, solver, cv, n_categories,
                                 n_categories_train=None, max_results=None,
                                 subset='all'):
-    from time import time
-
     cv = (cv == 'cv')
 
     if 'CIRCLECI' in os.environ and cv == 1 and solver in ['LinearSVC',
                                                            'xgboost']:
         raise SkipTest  # Circle CI is too slow and timesout
 
-    t0 = time()
     if solver.startswith('Nearest'):
         dsid, lsi_id, _, ds_input = get_features_lsi_cached(app, n_categories=n_categories)
         parent_id = lsi_id
@@ -76,7 +73,6 @@ def _api_categorization_wrapper(app, solver, cv, n_categories,
         dsid, _, ds_input = get_features_cached(app, n_categories=n_categories)
         lsi_id = None
         parent_id = dsid
-    print('Loading ds: {:.4f}'.format(time() - t0))
 
     method = V01 + "/feature-extraction/{}".format(dsid)
     data = app.get_check(method)

--- a/freediscovery/server/tests/test_clustering.py
+++ b/freediscovery/server/tests/test_clustering.py
@@ -42,6 +42,8 @@ def test_api_clustering(app, model, use_lsi, n_clusters, optimal_sampling):
         lsi_id = None
         parent_id = dsid
 
+    pars = { 'parent_id': parent_id, }
+
     if model == 'birch' and n_clusters <= 0:
         is_hierarchical = True
     else:
@@ -51,11 +53,12 @@ def test_api_clustering(app, model, use_lsi, n_clusters, optimal_sampling):
     data = app.get_check(method)
 
     url = V01 + "/clustering/" + model
-    pars = { 'parent_id': parent_id, }
     if model != 'dbscan':
         pars['n_clusters'] = n_clusters
     if model == 'dbscan':
         pars.update({'eps': 0.1, "min_samples": 2})
+    elif model == 'birch':
+        pars['min_similarity'] = 0.7
     data = app.post_check(url, json=pars)
 
     assert sorted(data.keys()) == sorted(['id'])

--- a/freediscovery/server/tests/test_email_threading.py
+++ b/freediscovery/server/tests/test_email_threading.py
@@ -1,22 +1,6 @@
 # -*- coding: utf-8 -*-
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-from __future__ import unicode_literals
-
-import os
-import pytest
-import json
-import itertools
-from unittest import SkipTest
 from numpy.testing import assert_equal, assert_almost_equal
-
-from .. import fd_app
-from ...utils import _silent, dict2type, sdict_keys
-from ...ingestion import DocumentIndex
-from ...exceptions import OptionalDependencyMissing
-from ...tests.run_suite import check_cache
 
 from .base import (parse_res, V01, app, app_notest, get_features, get_features_lsi,
                    email_data_dir)
@@ -31,23 +15,22 @@ from .base import (parse_res, V01, app, app_notest, get_features, get_features_l
 
 def test_api_thread_emails(app):
 
-    dsid, _ = get_features(app, parse_email_headers=True)
+    dsid, pars, _ = get_features(app, parse_email_headers=True,
+                                 dataset='fedora_ml_3k_subset')
 
-
-    url = V01 + "/email-threading" 
-    pars = { 'parent_id': dsid }
+    url = V01 + "/email-threading"
+    pars = {'parent_id': dsid}
 
     data = app.post_check(url, json=pars)
     assert sorted(data.keys()) == sorted(['data', 'id'])
     mid = data['id']
 
-    tree_ref = [ {'id': 0, 'parent': None, 'children': [
-                  {'id': 1, 'children': [], 'parent': 0},
-                  {'id': 2, 'parent': 0,  'children': [
-                         {'id': 3, 'children': [], 'parent': 2},
-                         {'id': 4, 'children': [], 'parent': 2}],
-                         }]
-                  }]
+    tree_ref = [{'id': 0, 'parent': None, 'children': [
+                 {'id': 1, 'children': [], 'parent': 0},
+                 {'id': 2, 'parent': 0,  'children': [
+                        {'id': 3, 'children': [], 'parent': 2},
+                        {'id': 4, 'children': [], 'parent': 2}]}]
+                 }]
 
     def remove_subject_field(d):
         del d['subject']

--- a/freediscovery/server/tests/test_exceptions.py
+++ b/freediscovery/server/tests/test_exceptions.py
@@ -13,7 +13,7 @@ from unittest import SkipTest
 from numpy.testing import assert_equal, assert_almost_equal
 
 from ...utils import _silent, dict2type, sdict_keys
-from .base import parse_res, V01, app, app_notest, get_features, get_features_lsi
+from .base import parse_res, V01, app, app_notest, get_features_cached, get_features_lsi
 
 
 #=============================================================================#
@@ -62,7 +62,7 @@ def test_get_model_predict_404(app_notest, method):
 
 
 def test_exception_handling(app_notest):
-    dsid, _ = get_features(app_notest)
+    dsid, pars, _ = get_features_cached(app_notest)
 
     method = V01 + "/categorization/"
     with _silent('stderr'):

--- a/freediscovery/server/tests/test_ingestion.py
+++ b/freediscovery/server/tests/test_ingestion.py
@@ -38,7 +38,7 @@ def test_get_features(app):
         assert val == data[key]
 
 def test_delete_feature_extraction(app):
-    dsid, _ = get_features(app)
+    dsid, pars, _ = get_features(app)
 
     method = V01 + "/feature-extraction/{}".format(dsid)
     app.delete_check(method)
@@ -80,16 +80,16 @@ def test_stop_words_integration(app, hashed):
             'stop_words': ['and', 'or', 'in']}
 
     res = app.post_check(url, json=pars)
-    assert dict2type(res, collapse_lists=True) == {'name' : 'str'}
+    assert dict2type(res, collapse_lists=True) == {'name': 'str'}
     assert res['name'] == sw_name
 
     res = app.get_check(url + sw_name)
-    assert dict2type(res, collapse_lists=True) == {'name' : 'str',
+    assert dict2type(res, collapse_lists=True) == {'name': 'str',
                                                    'stop_words': ['str']}
     assert res['name'] == sw_name
     assert res['stop_words'] == pars['stop_words']
 
-    dsid, _ = get_features(app, hashed=hashed, stop_words=sw_name)
+    dsid, pars, _ = get_features(app, hashed=hashed, stop_words=sw_name)
 
 
 
@@ -103,11 +103,11 @@ def test_get_search_filenames(app):
         return {key: val for key, val in x.items() if key == filter_field}
 
     response_ref = {'internal_id': 'int',
-                    'file_path' : 'str',
+                    'file_path': 'str',
                     'document_id': 'int'}
 
     # Query 1
-    file_path_obj  = [{'file_path': val} for val in ['00401.txt', '00506.txt']]
+    file_path_obj = [{'file_path': val} for val in ['00401.txt', '00506.txt']]
     data = app.post_check(method, json={'data': file_path_obj})
     data = data['data']
 
@@ -117,12 +117,11 @@ def test_get_search_filenames(app):
     assert_equal(np.asarray([row['internal_id'] for row in data])**2,
                  [row['document_id'] for row in data])
 
-
     with pytest.raises(NotFound):
         res = app.post(method, json={'data': [{'file_path': '00400.txt'}]})
 
     # Query 2
-    file_path_obj  = [{'document_id': 4 }, {'document_id': 9}]
+    file_path_obj = [{'document_id': 4}, {'document_id': 9}]
     data = app.post_check(method, json={'data': file_path_obj})
     data = data['data']
 
@@ -131,5 +130,3 @@ def test_get_search_filenames(app):
     assert [_filter_dict(row, 'document_id') for row in data] == file_path_obj
     assert_equal(np.asarray([row['internal_id'] for row in data])**2,
                  [row['document_id'] for row in data])
-
-

--- a/freediscovery/server/tests/test_lsi.py
+++ b/freediscovery/server/tests/test_lsi.py
@@ -18,7 +18,8 @@ from ...ingestion import DocumentIndex
 from ...exceptions import OptionalDependencyMissing
 from ...tests.run_suite import check_cache
 
-from .base import parse_res, V01, app, app_notest, get_features, get_features_lsi
+from .base import (parse_res, V01, app, app_notest,
+                   get_features_cached)
 
 
 #=============================================================================#
@@ -28,40 +29,30 @@ from .base import parse_res, V01, app, app_notest, get_features, get_features_ls
 #=============================================================================#
 
 def test_api_lsi(app):
-    dsid, _ = get_features(app)
+    dsid, pars, _ = get_features_cached(app)
     method = V01 + "/feature-extraction/{}".format(dsid)
     res = app.get(method)
     assert res.status_code == 200
     data = parse_res(res)
     method = V01 + "/lsi/"
-    res = app.get_check(method,
-            data=dict(
-                parent_id=dsid,
-                )
-            )
+    res = app.get_check(method, data=dict(parent_id=dsid))
 
-    lsi_pars = dict( n_components=101, parent_id=dsid)
+    lsi_pars = dict(n_components=101, parent_id=dsid)
     method = V01 + "/lsi/"
     data = app.post_check(method, json=lsi_pars)
     assert sorted(data.keys()) == ['explained_variance', 'id']
     lid = data['id']
 
-
     # checking again that we can load all the lsi models
     method = V01 + "/lsi/"
-    data = app.get(method,
-            data=dict(
-                parent_id=dsid,
-                )
-            )
+    data = app.get(method, data=dict(parent_id=dsid,))
 
     method = V01 + "/lsi/{}".format(lid)
     data = app.get_check(method)
     for key, vals in lsi_pars.items():
         assert vals == data[key]
 
-    assert sorted(data.keys()) == \
-            sorted(["n_components", "parent_id"])
+    assert sorted(data.keys()) == sorted(["n_components", "parent_id"])
 
     for key in data.keys():
         assert data[key] == lsi_pars[key]

--- a/freediscovery/tests/run_suite.py
+++ b/freediscovery/tests/run_suite.py
@@ -34,7 +34,7 @@ def check_cache(test_env=True):
     else:
         subfolder = 'freediscovery-cache'
 
-    cache_dir, _ = _get_temp_dir(subfolder)
+    cache_dir, _ = _get_temp_dir(subfolder, temp_folder=tempfile.gettempdir())
 
     if not os.path.exists(cache_dir):
         os.mkdir(cache_dir)
@@ -43,5 +43,3 @@ def check_cache(test_env=True):
 
 if __name__ == '__main__':
     run_cli()
-
-

--- a/freediscovery/tests/test_categorize.py
+++ b/freediscovery/tests/test_categorize.py
@@ -17,7 +17,7 @@ from freediscovery.lsi import _LSIWrapper
 from freediscovery.categorization import _CategorizerWrapper
 from freediscovery.io import parse_ground_truth_file
 from freediscovery.metrics import categorization_score
-from freediscovery.exceptions import OptionalDependencyMissing
+from freediscovery.exceptions import OptionalDependencyMissing, WrongParameter
 from .run_suite import check_cache
 
 
@@ -47,6 +47,7 @@ _test_cases = itertools.product(
                        ["LinearSVC", "LogisticRegression", 'xgboost',
                         "NearestNeighbor", "NearestCentroid"],
                        [None, 'fast'])
+
 # 'MLPClassifier', 'ensemble-stacking' not supported in production the moment
 _test_cases = filter(lambda x: not (x[1].startswith("Nearest") and x[2]),
                      _test_cases)
@@ -83,6 +84,11 @@ def test_categorization(use_lsi, method, cv):
                                 cv=cv)
     except OptionalDependencyMissing:
         raise SkipTest
+    except WrongParameter:
+        if method in ['NearestNeighbor', 'NearestCentroid']:
+            return
+        else:
+            raise
 
     Y_pred, md = cat.predict()
     X_pred = np.arange(cat.fe.n_samples_, dtype='int')

--- a/freediscovery/tests/test_text.py
+++ b/freediscovery/tests/test_text.py
@@ -239,18 +239,14 @@ def test_sampling_filenames():
     fe.delete()
 
 
-@pytest.mark.parametrize("analyzer, ngram_range, use_hashing",
-                         list(itertools.product(['word', 'char'],
-                                                [[1, 1], [1, 2]],
-                                                ['hashed', 'non-hashed'])))
-def test_feature_extraction_cyrillic(analyzer, ngram_range, use_hashing):
+@pytest.mark.parametrize("use_hashing", ['hashed', 'non-hashed'])
+def test_feature_extraction_cyrillic(use_hashing):
     data_dir = os.path.join(basename, "..", "data", "ds_002", "raw")
     cache_dir = check_cache()
     use_hashing = (use_hashing == 'hashed')
 
     fe = FeatureVectorizer(cache_dir=cache_dir)
     uuid = fe.preprocess(data_dir, file_pattern='.*\d.txt',
-                         analyzer=analyzer, ngram_range=ngram_range,
                          use_hashing=use_hashing)
     fe.transform()
 
@@ -261,7 +257,8 @@ def test_feature_extraction_cyrillic(analyzer, ngram_range, use_hashing):
     filenames2 = fe.filenames_
 
     assert_equal(filenames2, filenames)
-    assert isinstance(res2,  np.ndarray) or scipy.sparse.issparse(res2), "not an array {}".format(res2)
+    assert isinstance(res2,  np.ndarray) or scipy.sparse.issparse(res2),\
+        "not an array {}".format(res2)
 
     assert np.isfinite(res2.data).all()
     fe.delete()


### PR DESCRIPTION
This PR,
  - enforces that computing nearest neighbors on documents without applying an LSI preprocessing step would raise an error (except in the case when the query is user provided and contains only key words) (issue #126 )
  - renames `nn_metric` parameter to `metric`
  - adds additional tests to semantic search / categorization
  - removes no longer necessary `from __future__` imports.