### PR TITLE
Batched data ingestion from JSON

### DIFF
--- a/doc/contributing.md
+++ b/doc/contributing.md
@@ -53,7 +53,7 @@ which requires to install dependencies in `build_tools/requirements_extra_pip.tx
 
 Alternatively  `make latexpdf` generates documentation in .pdf format (requires `pdflatex`). 
 
-## 2. REST API documentation
+### 2. REST API documentation
 
 The rest API documentation can be generated with,
 

--- a/examples/REST_clustering.py
+++ b/examples/REST_clustering.py
@@ -33,8 +33,7 @@ dataset_definition = [{'document_id': row['document_id'],
 print("\n1.a Load dataset and initalize feature extraction")
 url = BASE_URL + '/feature-extraction'
 print(" POST", url)
-fe_opts = {'dataset_definition': dataset_definition,
-           #'min_df': 4, 'max_df': 0.75  # filter out (too)/(un)frequent words
+fe_opts = {  # 'min_df': 4, 'max_df': 0.75  # filter out (too)/(un)frequent words
            }
 res = requests.post(url, json=fe_opts).json()
 
@@ -47,7 +46,7 @@ print("\n1.b Run feature extraction")
 # progress status is available for the hashed version only
 url = BASE_URL+'/feature-extraction/{}'.format(dsid)
 print(" POST", url)
-res = requests.post(url)
+res = requests.post(url, json={'dataset_definition': dataset_definition})
 
 print("\n1.d. check the parameters of the extracted features")
 url = BASE_URL + '/feature-extraction/{}'.format(dsid)

--- a/examples/REST_data_ingestion.py
+++ b/examples/REST_data_ingestion.py
@@ -34,13 +34,11 @@ if __name__ == '__main__':
                                    for row in input_ds['dataset']]
 
 
-    # 1. Ingest a dataset specified by folder path
-
+    # 2. Ingest a dataset specified by a path to each file in the dataset
     print("\n1.a Load dataset and initalize feature extraction")
     url = BASE_URL + '/feature-extraction'
     print(" POST", url)
-    res = requests.post(url, json={'dataset_definition': dataset_definition,
-                                   'use_hashing': True}).json()
+    res = requests.post(url, json={'use_hashing': True}).json()
 
     dsid = res['id']
     print("   => received {}".format(list(res.keys())))
@@ -50,26 +48,7 @@ if __name__ == '__main__':
 
     url = BASE_URL+'/feature-extraction/{}'.format(dsid)
     print(" POST", url)
-    res = requests.post(url,)
-
-    # 2. Ingest a dataset specified by a path to each file in the dataset
-
-
-    print("\n2.a Load dataset and initalize feature extraction")
-    url = BASE_URL + '/feature-extraction'
-    print(" POST", url)
-    res = requests.post(url, json={'dataset_definition': dataset_definition,
-                                   'use_hashing': True}).json()
-
-    dsid = res['id']
-    print("   => received {}".format(list(res.keys())))
-    print("   => dsid = {}".format(dsid))
-
-    print("\n2.b Start feature extraction")
-
-    url = BASE_URL+'/feature-extraction/{}'.format(dsid)
-    print(" POST", url)
-    res = requests.post(url,)
+    res = requests.post(url, json={'dataset_definition': dataset_definition})
 
 
     print("\n2.d. check the parameters of the extracted features")
@@ -77,8 +56,8 @@ if __name__ == '__main__':
     print(' GET', url)
     res = requests.get(url).json()
 
-    print('\n'.join(['     - {}: {}'.format(key, val) for key, val in res.items() \
-                                                      if "filenames" not in key]))
+    print('\n'.join(['     - {}: {}'.format(key, val)
+          for key, val in res.items() if "filenames" not in key]))
 
     print("\n3. Examine the id mapping\n")
 

--- a/examples/REST_duplicate_detection.py
+++ b/examples/REST_duplicate_detection.py
@@ -35,11 +35,10 @@ data_dir = input_ds['metadata']['data_dir']
 print("\n1.a Load dataset and initalize feature extraction")
 url = BASE_URL + '/feature-extraction'
 print(" POST", url)
-fe_opts = {'data_dir': data_dir,
-           'use_idf': 1, # this is required to compute cluster labels (for now)
+fe_opts = {'use_idf': 1,  # this is required to compute cluster labels (for now)
            'n_features': 30001,
            'min_df': 4, 'max_df': 0.75
-          }
+           }
 res = requests.post(url, json=fe_opts)
 
 dsid = res.json()['id']
@@ -51,7 +50,7 @@ print("\n1.b Run feature extraction")
 # progress status is available for the hashed version only
 url = BASE_URL+'/feature-extraction/{}'.format(dsid)
 print(" POST", url)
-res = requests.post(url)
+res = requests.post(url, json={"data_dir": data_dir})
 
 print("\n1.d. check the parameters of the extracted features")
 url = BASE_URL + '/feature-extraction/{}'.format(dsid)
@@ -59,8 +58,8 @@ print(' GET', url)
 res = requests.get(url)
 
 data = res.json()
-print('\n'.join(['     - {}: {}'.format(key, val) for key, val in data.items() \
-                                                  if "filenames" not in key]))
+print('\n'.join(['     - {}: {}'.format(key, val)
+      for key, val in data.items() if "filenames" not in key]))
 
 
 print("\n2. Near Duplicates detection by cosine similarity (DBSCAN)")

--- a/examples/REST_email_threading.py
+++ b/examples/REST_email_threading.py
@@ -9,21 +9,17 @@ from __future__ import print_function
 from time import time
 import sys
 import platform
-from itertools import groupby
+import sys
 
-import numpy as np
 import pandas as pd
 import requests
-import sys
-import os
 
 pd.options.display.float_format = '{:,.3f}'.format
 
 
 if platform.system() == 'Windows' and sys.version_info > (3, 0):
-   print('This example currently fails on Windows with PY3 (issue #')
-   sys.exit()
-
+    print('This example currently fails on Windows with PY3 (issue #')
+    sys.exit()
 
 dataset_name = "fedora_ml_3k_subset"     # see list of available datasets
 
@@ -42,8 +38,7 @@ data_dir = res['metadata']['data_dir']
 print("\n1.a Parse emails")
 url = BASE_URL + '/feature-extraction'
 print(" POST", url)
-res = requests.post(url, json={'data_dir': data_dir,
-                               'parse_email_headers': True}).json()
+res = requests.post(url, json={'parse_email_headers': True}).json()
 
 dsid = res['id']
 print("   => received {}".format(list(res.keys())))
@@ -52,7 +47,7 @@ print("   => dsid = {}".format(dsid))
 
 url = BASE_URL+'/feature-extraction/{}'.format(dsid)
 print(" POST", url)
-requests.post(url)
+requests.post(url, json={'data_dir': data_dir})
 
 
 print("\n2. Email threading")
@@ -60,10 +55,9 @@ print("\n2. Email threading")
 url = BASE_URL + '/email-threading/'
 print(" POST", url)
 t0 = time()
-res = requests.post(url,
-        json={'parent_id': dsid }).json()
+res = requests.post(url, json={'parent_id': dsid}).json()
 
-mid  = res['id']
+mid = res['id']
 print("     => model id = {}".format(mid))
 
 

--- a/examples/REST_semantic_search.py
+++ b/examples/REST_semantic_search.py
@@ -28,16 +28,15 @@ if __name__ == '__main__':
     # create a custom dataset definition for ingestion
     data_dir = input_ds['metadata']['data_dir']
     dataset_definition = [{'document_id': row['document_id'],
-                           'file_path': os.path.join(data_dir, row['file_path'])} \
-                                   for row in input_ds['dataset']]
+                           'file_path': os.path.join(data_dir, row['file_path'])}
+                          for row in input_ds['dataset']]
 
     # 1. Feature extraction
 
     print("\n1.a Load dataset and initalize feature extraction")
     url = BASE_URL + '/feature-extraction'
     print(" POST", url)
-    res = requests.post(url, json={'dataset_definition': dataset_definition,
-                                   'use_hashing': True}).json()
+    res = requests.post(url).json()
 
     dsid = res['id']
     print("   => received {}".format(list(res.keys())))
@@ -47,7 +46,7 @@ if __name__ == '__main__':
 
     url = BASE_URL+'/feature-extraction/{}'.format(dsid)
     print(" POST", url)
-    requests.post(url)
+    requests.post(url, json={'dataset_definition': dataset_definition})
 
     # 3. Document categorization with LSI (used for Nearest Neighbors method)
 

--- a/freediscovery/cluster/base.py
+++ b/freediscovery/cluster/base.py
@@ -1,7 +1,6 @@
 # -*- coding: utf-8 -*-
 
 import os
-import os.path
 import sys
 
 import numpy as np
@@ -195,7 +194,7 @@ class _ClusteringWrapper(_BaseWrapper, _BaseClusteringWrapper):
         self._fit_X = None
 
     def _load_htree(self):
-        return joblib.load(os.path.join(self.model_dir, self.mid, 'htree'))
+        return joblib.load(str(self.model_dir / self.mid / 'htree'))
 
     def _cluster_func(self, n_clusters, km, pars=None):
         """ A helper function for clustering, includes base method used by
@@ -252,9 +251,9 @@ class _ClusteringWrapper(_BaseWrapper, _BaseClusteringWrapper):
 
         pars['n_clusters'] = n_clusters
 
-        joblib.dump(km, os.path.join(self.model_dir, mid,  'model'))
-        joblib.dump(htree, os.path.join(self.model_dir, mid,  'htree'))
-        joblib.dump(pars, os.path.join(self.model_dir, mid,  'pars'))
+        joblib.dump(km, str(self.model_dir / mid / 'model'))
+        joblib.dump(htree, str(self.model_dir / mid / 'htree'))
+        joblib.dump(pars, str(self.model_dir / mid / 'pars'))
 
         self.km = km
         self.htree = htree
@@ -299,8 +298,8 @@ class _ClusteringWrapper(_BaseWrapper, _BaseClusteringWrapper):
         vect = self.fe.vect_
 
         if 'lsi' in self.pipeline:
-            lsi = joblib.load(os.path.join(
-                              self.pipeline.get_path(self.pipeline['lsi']),
+            lsi = joblib.load(str(
+                              self.pipeline.get_path(self.pipeline['lsi']) /
                               'model'))
         else:
             lsi = None

--- a/freediscovery/datasets.py
+++ b/freediscovery/datasets.py
@@ -204,6 +204,7 @@ def load_dataset(name='20newsgroups_3categories', cache_dir='/tmp',
     md = {'data_dir': str(data_dir), 'name': name}
 
     di = DocumentIndex.from_folder(str(data_dir))
+    di._make_relative_paths()
 
     training_set = None
 

--- a/freediscovery/email_threading.py
+++ b/freediscovery/email_threading.py
@@ -40,17 +40,17 @@ class _EmailThreadingWrapper(_BaseWrapper):
                  decode_header=False):
 
         super(_EmailThreadingWrapper, self).__init__(cache_dir=cache_dir,
-                                          parent_id=parent_id, mid=mid,
-                                          load_model=True)
+                                                     parent_id=parent_id,
+                                                     mid=mid,
+                                                     load_model=True)
 
         if not os.path.exists(os.path.join(self.fe.dsid_dir, 'email_metadata')):
             raise ValueError('The email metadata was not found. Please rerun'
                              ' feature extraction with `parse_email_headers=True`'
                              ' option')
 
-
     def thread(self, index=None, group_by_subject=False,
-            sort_by_key='message_idx', sort_missing=-1):
+               sort_by_key='message_idx', sort_missing=-1):
         """
         Thread the emails
 
@@ -92,14 +92,12 @@ class _EmailThreadingWrapper(_BaseWrapper):
 
         mid, mid_dir = setup_model(self.model_dir)
 
-
         pars = {
             'group_by_subject': group_by_subject
         }
         self._pars = pars
         joblib.dump(pars, os.path.join(mid_dir, 'pars'))
         joblib.dump(cmod, os.path.join(mid_dir, 'model'))
-
 
         self.mid = mid
         self.cmod = cmod

--- a/freediscovery/email_threading.py
+++ b/freediscovery/email_threading.py
@@ -1,21 +1,10 @@
 # -*- coding  utf-8 -*-
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-from __future__ import unicode_literals
-
-import os
 import numpy as np
-import scipy
-from scipy.special import logit
 from sklearn.externals import joblib
 
-from .text import FeatureVectorizer
 from .base import _BaseWrapper
-from .utils import setup_model, INT_NAN
-from .exceptions import (ModelNotFound, WrongParameter,
-             NotImplementedFD, OptionalDependencyMissing)
+from .utils import setup_model
 
 from .externals import jwzthreading as jwzt
 
@@ -44,10 +33,10 @@ class _EmailThreadingWrapper(_BaseWrapper):
                                                      mid=mid,
                                                      load_model=True)
 
-        if not os.path.exists(os.path.join(self.fe.dsid_dir, 'email_metadata')):
+        if not (self.fe.dsid_dir / 'email_metadata').exists():
             raise ValueError('The email metadata was not found. Please rerun'
-                             ' feature extraction with `parse_email_headers=True`'
-                             ' option')
+                             ' feature extraction with '
+                             '`parse_email_headers=True` option')
 
     def thread(self, index=None, group_by_subject=False,
                sort_by_key='message_idx', sort_missing=-1):
@@ -79,14 +68,14 @@ class _EmailThreadingWrapper(_BaseWrapper):
         if index is None:
             index = np.arange(self.fe.n_samples_)
 
-        d_all = joblib.load(os.path.join(self.fe.dsid_dir, 'email_metadata'))
+        d_all = joblib.load(str(self.fe.dsid_dir / 'email_metadata'))
 
         threads = jwzt.thread(d_all, group_by_subject)
 
         threads = [el.collapse_empty() for el in threads]
 
         threads = jwzt.sort_threads(threads, key=sort_by_key,
-                                             missing=sort_missing)
+                                    missing=sort_missing)
 
         cmod = threads
 
@@ -96,10 +85,9 @@ class _EmailThreadingWrapper(_BaseWrapper):
             'group_by_subject': group_by_subject
         }
         self._pars = pars
-        joblib.dump(pars, os.path.join(mid_dir, 'pars'))
-        joblib.dump(cmod, os.path.join(mid_dir, 'model'))
+        joblib.dump(pars, str(mid_dir / 'pars'))
+        joblib.dump(cmod, str(mid_dir / 'model'))
 
         self.mid = mid
         self.cmod = cmod
         return cmod
-

--- a/freediscovery/ingestion.py
+++ b/freediscovery/ingestion.py
@@ -1,10 +1,5 @@
 # -*- coding: utf-8 -*-
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-from __future__ import unicode_literals
-
 import os.path
 import os
 import pandas as pd
@@ -327,7 +322,8 @@ class DocumentIndex(object):
             raise IOError('data_dir={} does not exist!'.format(data_dir))
 
     @classmethod
-    def from_folder(cls, data_dir, file_pattern=None, dir_pattern=None):
+    def from_folder(cls, data_dir, file_pattern=None, dir_pattern=None,
+                    internal_id_offset=0):
         """ Create a DocumentIndex from files in data_dir
 
         Parmaters
@@ -349,7 +345,7 @@ class DocumentIndex(object):
 
         filenames = _list_filenames(data_dir, dir_pattern, file_pattern)
         filenames_rel = [os.path.relpath(el, data_dir) for el in filenames]
-        db = [{'file_path': file_path, 'internal_id': idx}
+        db = [{'file_path': file_path, 'internal_id': idx + internal_id_offset}
               for idx, file_path in enumerate(filenames_rel)]
 
         db = pd.DataFrame(db)

--- a/freediscovery/ingestion.py
+++ b/freediscovery/ingestion.py
@@ -317,7 +317,7 @@ class DocumentIndex(object):
                 file_path_el = '{:09}_{}.txt'.format(idx + internal_id_offset,
                                                      rendering_id_el)
                 db_el['file_path'] = os.path.join(data_dir, file_path_el)
-                with (dsid_dir / 'raw' / file_path_el).open('wt') as fh:
+                with (dsid_dir / 'raw' / file_path_el).open('wt', encoding='utf-8') as fh:
                     fh.write(db_el.pop('content'))
 
         elif (~has_file_path).any():
@@ -389,6 +389,9 @@ class DocumentIndex(object):
     def _make_relative_paths(self):
         """ By default DocumentIndex uses absolute file paths,
         this makes the file_path to be relative to dir_path"""
+        if self.data_dir is None:
+            self.data_dir = self._detect_data_dir(self.filenames_)
+
         self.filenames_ = [os.path.relpath(el, self.data_dir)
                            for el in self.filenames_]
         self.data['file_path'] = self.filenames_

--- a/freediscovery/lsi.py
+++ b/freediscovery/lsi.py
@@ -1,10 +1,5 @@
 # -*- coding: utf-8 -*-
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-
-import os.path
 import numpy as np
 import scipy.sparse as sp
 from scipy.sparse.linalg import svds
@@ -47,8 +42,8 @@ class _LSIWrapper(_BaseWrapper):
                                           parent_id=parent_id, mid=mid)
 
     def _load_features(self):
-        mid_dir = os.path.join(self.fe.dsid_dir, self._wrapper_type, self.mid)
-        return joblib.load(os.path.join(mid_dir, 'data'))
+        mid_dir = self.fe.dsid_dir / self._wrapper_type / self.mid
+        return joblib.load(str(mid_dir / 'data'))
 
     def fit_transform(self, n_components=150, n_iter=5):
         """
@@ -74,15 +69,15 @@ class _LSIWrapper(_BaseWrapper):
         parent_id = self.pipeline.mid
 
         dsid_dir = self.fe.dsid_dir
-        if not os.path.exists(dsid_dir):
+        if not dsid_dir.exists():
             raise IOError
 
         pars = {'parent_id': parent_id, 'n_components': n_components}
 
-        mid_dir_base = os.path.join(dsid_dir, self._wrapper_type)
+        mid_dir_base = dsid_dir / self._wrapper_type
 
-        if not os.path.exists(mid_dir_base):
-            os.mkdir(mid_dir_base)
+        if not mid_dir_base.exists():
+            mid_dir_base.mkdir()
         mid, mid_dir = setup_model(mid_dir_base)
 
         ds = self.pipeline.data
@@ -93,9 +88,9 @@ class _LSIWrapper(_BaseWrapper):
 
         ds_p = lsi.transform_lsi_norm(ds)
 
-        joblib.dump(pars, os.path.join(mid_dir, 'pars'))
-        joblib.dump(lsi, os.path.join(mid_dir, 'model'))
-        joblib.dump(ds_p, os.path.join(mid_dir, 'data'))
+        joblib.dump(pars, str(mid_dir / 'pars'))
+        joblib.dump(lsi, str(mid_dir / 'model'))
+        joblib.dump(ds_p, str(mid_dir / 'data'))
 
         exp_var = lsi.explained_variance_ratio_.sum()
         self.mid = mid
@@ -111,12 +106,12 @@ class _LSIWrapper(_BaseWrapper):
           the additional data to add to the index
 
         """
-        mid_dir = os.path.join(self.model_dir, self.mid)
-        lsi = joblib.load(os.path.join(mid_dir, 'model'))
-        Y_old = joblib.load(os.path.join(mid_dir, 'data'))
+        mid_dir = self.model_dir / self.mid
+        lsi = joblib.load(str(mid_dir / 'model'))
+        Y_old = joblib.load(str(mid_dir / 'data'))
         Y_new = lsi.transform_lsi_norm(X)
         Y = np.vstack((Y_old, Y_new))
-        joblib.dump(Y, os.path.join(mid_dir, 'data'))
+        joblib.dump(Y, str(mid_dir / 'data'))
 
 
 # The below class is identical to TruncatedSVD,

--- a/freediscovery/pipeline.py
+++ b/freediscovery/pipeline.py
@@ -7,6 +7,7 @@ from __future__ import unicode_literals
 
 import os
 from collections import OrderedDict
+from pathlib import Path
 from .exceptions import (DatasetNotFound, InitException, ModelNotFound, WrongParameter)
 
 from sklearn.externals import joblib
@@ -73,10 +74,10 @@ class PipelineFinder(OrderedDict):
         """ Normalize the cachedir path. This ensures that the cache_dir
         ends with "ediscovery_cache"
         """
-        cache_dir = os.path.normpath(cache_dir)
+        cache_dir = os.path.normpath(str(cache_dir))
         if 'ediscovery_cache' not in cache_dir:  # not very pretty
             cache_dir = os.path.join(cache_dir, "ediscovery_cache")
-        return cache_dir
+        return Path(cache_dir)
 
     @classmethod
     def by_id(cls, mid, cache_dir="/tmp/"):
@@ -99,10 +100,10 @@ class PipelineFinder(OrderedDict):
 
         pipeline = cls(mid=mid, cache_dir=cache_dir)
 
-        cache_dir_base = os.path.dirname(cache_dir)
+        cache_dir_base = cache_dir.parent
         _break_flag = False
-        for root, subdirs, files in os.walk(cache_dir):
-            root = os.path.relpath(root, cache_dir_base)
+        for root, subdirs, files in os.walk(str(cache_dir)):
+            root = os.path.relpath(root, str(cache_dir_base))
             for sdir in subdirs:
                 path = os.path.join(root, sdir)
                 path_hierarchy = _split_path(path)
@@ -159,10 +160,10 @@ class PipelineFinder(OrderedDict):
         ds_path = self.get_path(self[last_node])
 
         if last_node == "vectorizer":
-            full_path = os.path.join(ds_path, 'features')
+            full_path = ds_path / 'features'
         elif last_node == 'lsi':
-            full_path = os.path.join(ds_path, 'data')
-        return joblib.load(full_path)
+            full_path = ds_path / 'data'
+        return joblib.load(str(full_path))
 
     def get_path(self, mid=None, absolute=True):
         """ Find the path to the model specified by mid """
@@ -180,7 +181,7 @@ class PipelineFinder(OrderedDict):
         if absolute:
             del path[0]  # "ediscovery_cache" is already present in cache_dir
             rel_path = os.path.join(*path)
-            return os.path.join(self.cache_dir, rel_path)
+            return self.cache_dir / rel_path
         else:
             path[0] = 'ediscovery_cache'
-            return os.path.join(*path)
+            return Path(os.path.join(*path))

--- a/freediscovery/search.py
+++ b/freediscovery/search.py
@@ -1,13 +1,11 @@
 # -*- coding: utf-8 -*-
 
-import os
 import warnings
 
 from sklearn.metrics import pairwise_distances
 from sklearn.externals import joblib
 
 from .base import _BaseWrapper
-from .exceptions import WrongParameter
 
 
 class _SearchWrapper(_BaseWrapper):
@@ -49,11 +47,11 @@ class _SearchWrapper(_BaseWrapper):
         if internal_id is not None:
             if 'lsi' not in self.pipeline:
                 warnings.warn('Search using a document_id as a query'
-                                     ' should not be applied in the space of '
-                                     ' raw document term vectors due'
-                                     ' to the curse of dimensionality.'
-                                     ' Please add an LSI processing'
-                                     ' step (i.e. use `parent_id=lsi_id`)')
+                              ' should not be applied in the space of '
+                              ' raw document term vectors due'
+                              ' to the curse of dimensionality.'
+                              ' Please add an LSI processing'
+                              ' step (i.e. use `parent_id=lsi_id`)')
             vect = None
         else:
             vect = self.fe.vect_
@@ -62,8 +60,8 @@ class _SearchWrapper(_BaseWrapper):
         X = self.pipeline.data
 
         if "lsi" in self.pipeline:
-            lsi = joblib.load(os.path.join(
-                              self.pipeline.get_path(self.pipeline['lsi']),
+            lsi = joblib.load(str(
+                              self.pipeline.get_path(self.pipeline['lsi']) /
                               'model'))
         else:
             lsi = None

--- a/freediscovery/server/resources.py
+++ b/freediscovery/server/resources.py
@@ -151,13 +151,10 @@ class FeaturesApiElement(Resource):
         sc = FeaturesSchema()
         fe = FeatureVectorizer(self._cache_dir, dsid=dsid)
         out = fe.pars_.copy()
-        is_processing = os.path.exists(os.path.join(fe.cache_dir,
-                                                    dsid, 'processing'))
-        is_finished = os.path.exists(os.path.join(fe.cache_dir,
-                                                  dsid, 'processing_finished'))
+        is_processing = (fe.cache_dir / dsid / 'processing').exists()
+        is_finished = (fe.cache_dir / dsid / 'processing_finished').exists()
         if is_processing and not is_finished:
-            n_chunks = len(glob(os.path.join(fe.cache_dir,
-                                             dsid, 'features-*[0-9]')))
+            n_chunks = len((fe.cache_dir / dsid).glob('features-*[0-9]'))
             out['n_samples_processed'] = min(n_chunks*out['chunk_size'],
                                              out['n_samples'])
             return sc.dump(out).data, 202
@@ -172,7 +169,7 @@ class FeaturesApiElement(Resource):
 
     @doc(description=dedent("""
          Run feature extraction on a dataset,
-         
+
          **Parameters**
           - `data_dir`: [optional] relative path to the directory with the input files. Either `data_dir` or `dataset_definition` must be provided.
           - `dataset_definition`: [optional] a list of dictionaries `[{'file_path': <str>, 'document_id': <int>, 'rendition_id': <int>}, ...]` where `document_id` and `rendition_id` are optional. Either `data_dir` or `dataset_definition` must be provided.

--- a/freediscovery/server/resources.py
+++ b/freediscovery/server/resources.py
@@ -173,14 +173,15 @@ class FeaturesApiElement(Resource):
          **Parameters**
           - `data_dir`: [optional] relative path to the directory with the input files. Either `data_dir` or `dataset_definition` must be provided.
           - `dataset_definition`: [optional] a list of dictionaries `[{'file_path': <str>, 'document_id': <int>, 'rendition_id': <int>}, ...]` where `document_id` and `rendition_id` are optional. Either `data_dir` or `dataset_definition` must be provided.
+          - `vectorize`: [optional] this option can be used to ingest the dataset_definition in batches (optionally with document content), then make one final call to vectorize all sent documents (bool, default: True)
          """))
     @use_args({"data_dir":  wfields.Str(),
-               "dataset_definition": wfields.Nested(_DatasetDefinition, many=True)})
+               "dataset_definition": wfields.Nested(_DatasetDefinition, many=True),
+               "vectorize": wfields.Bool(missing=True)})
     @marshal_with(IDSchema())
     def post(self, dsid, **args):
         fe = FeatureVectorizer(self._cache_dir, dsid=dsid)
         fe.ingest(**args)
-        fe.transform()
         if fe.pars_['parse_email_headers']:
             fe.parse_email_headers()
         return {'id': fe.dsid}

--- a/freediscovery/server/resources.py
+++ b/freediscovery/server/resources.py
@@ -36,7 +36,7 @@ from ..stop_words import _StopWordsWrapper
 from .validators import _is_in_range
 
 from .schemas import (IDSchema, FeaturesParsSchema,
-                      FeaturesSchema,
+                      FeaturesSchema, _DatasetDefinitionShort,
                       DocumentIndexNestedSchema, _DatasetDefinition,
                       ExampleDatasetSchema, DocumentIndexFullSchema,
                       LsiParsSchema, LsiPostSchema,
@@ -260,8 +260,8 @@ class FeaturesApiRemove(Resource):
          **Parameters**
           - `dataset_definition`: [optional] a list of dictionaries `[{'file_path': <str>, 'document_id': <int>, 'rendition_id': <int>}, ...]` where  `rendition_id` are optional.
           """))
-    @use_args({'dataset_definition': wfields.Nested(_DatasetDefinition, many=True,
-                                                    required=True)})
+    @use_args({'dataset_definition': wfields.Nested(_DatasetDefinitionShort,
+                                                    many=True, required=True)})
     @marshal_with(EmptySchema())
     def post(self, dsid, **args):
         fe = FeatureVectorizer(self._cache_dir, dsid=dsid)

--- a/freediscovery/server/resources.py
+++ b/freediscovery/server/resources.py
@@ -235,14 +235,16 @@ class FeaturesApiAppend(Resource):
          need to be re-trained.
 
          **Parameters**
+          - `data_dir`: [optional] relative path to the directory with the input files. Either `data_dir` or `dataset_definition` must be provided.
           - `dataset_definition`: [optional] a list of dictionaries `[{'file_path': <str>, 'document_id': <int>, 'rendition_id': <int>}, ...]` where  `rendition_id` are optional.
           """))
-    @use_args({'dataset_definition': wfields.Nested(_DatasetDefinition, many=True,
+    @use_args({'data_dir': wfields.Str(),
+               'dataset_definition': wfields.Nested(_DatasetDefinition, many=True,
                                                     required=True)})
     @marshal_with(EmptySchema())
     def post(self, dsid, **args):
         fe = FeatureVectorizer(self._cache_dir, dsid=dsid)
-        fe.append(args['dataset_definition'])
+        fe.append(**args)
         return {}
 
 

--- a/freediscovery/server/schemas.py
+++ b/freediscovery/server/schemas.py
@@ -56,6 +56,13 @@ class _DatasetDefinition(Schema):
     document_id = fields.Int()
     rendition_id = fields.Int()
     file_path = fields.Str()
+    content = fields.Str()
+
+
+class _DatasetDefinitionShort(Schema):
+    document_id = fields.Int()
+    rendition_id = fields.Int()
+    file_path = fields.Str()
 
 
 class FeaturesParsSchema(Schema):

--- a/freediscovery/server/schemas.py
+++ b/freediscovery/server/schemas.py
@@ -60,8 +60,6 @@ class _DatasetDefinition(Schema):
 
 class FeaturesParsSchema(Schema):
     data_dir = fields.Str()
-    dataset_definition = fields.Nested(_DatasetDefinition, many=True)
-    dir_pattern = fields.Str()
     n_features = fields.Int(missing=100001)
     analyzer = fields.Str(missing='word')
     stop_words = fields.Str()

--- a/freediscovery/server/tests/test_ingestion.py
+++ b/freediscovery/server/tests/test_ingestion.py
@@ -126,10 +126,10 @@ def test_get_search_filenames(app):
 
 def test_append_documents(app):
     method = V01 + "/feature-extraction/"
-    data = app.post_check(method, json={'data_dir': data_dir})
+    data = app.post_check(method)
     dsid = data['id']
     method += dsid
-    app.post_check(method)
+    app.post_check(method, json={'data_dir': data_dir})
 
     data = app.get_check(method)
 
@@ -159,10 +159,10 @@ def test_append_documents(app):
 
 def test_remove_documents(app):
     method = V01 + "/feature-extraction/"
-    data = app.post_check(method, json={'data_dir': data_dir})
+    data = app.post_check(method)
     dsid = data['id']
     method += dsid
-    app.post_check(method)
+    app.post_check(method, json={'data_dir': data_dir})
 
     data = app.get_check(method)
 

--- a/freediscovery/server/tests/test_ingestion.py
+++ b/freediscovery/server/tests/test_ingestion.py
@@ -153,7 +153,7 @@ def test_append_documents(app, ingestion_method):
         if ingestion_method == 'file_path':
             row_out['file_path'] = os.path.join(data_dir, row['file_path'])
         elif ingestion_method == 'content':
-            with Path(data_dir, row['file_path']).open('rt') as fh:
+            with Path(data_dir, row['file_path']).open('rt', encoding='utf-8') as fh:
                 row_out['content'] = fh.read()
         dataset_definition.append(row_out)
 
@@ -204,7 +204,7 @@ def test_batch_ingest(app, ingestion_method):
         dd = []
         for fname in data_dir_k.glob('*txt'):
             if ingestion_method == 'content':
-                with fname.open('rt') as fh:
+                with fname.open('rt', encoding='utf-8') as fh:
                     dd.append({'content': fh.read()})
             elif ingestion_method == 'file_path':
                 dd.append({'file_path': str(fname)})

--- a/freediscovery/server/tests/test_search.py
+++ b/freediscovery/server/tests/test_search.py
@@ -238,9 +238,9 @@ def test_ingestion_no_document_id_provided(app):
     data_dir = os.path.dirname(__file__)
     data_dir = os.path.join(data_dir, "..", "..", "data", "ds_001", "raw")
     method = V01 + "/feature-extraction/"
-    data = app.post_check(method, json={'data_dir': data_dir})
+    data = app.post_check(method)
     dsid = data['id']
-    app.post_check(method + dsid)
+    app.post_check(method + dsid, json={'data_dir': data_dir})
 
     data = app.post_check(V01 + "/search/", json={'parent_id': dsid,
                                                   'query': 'test'})

--- a/freediscovery/stop_words.py
+++ b/freediscovery/stop_words.py
@@ -191,10 +191,10 @@ class _StopWordsWrapper(object):
           the cache directory
         """
         self.cache_dir = PipelineFinder._normalize_cachedir(cache_dir)
-        self.model_dir = os.path.join(self.cache_dir, 'stop_words')
+        self.model_dir = self.cache_dir / 'stop_words'
 
-        if not os.path.exists(self.model_dir):
-            os.makedirs(self.model_dir)
+        if not self.model_dir.exists():
+            self.model_dir.mkdir()
 
     def save(self, name, stop_words):
         """
@@ -211,31 +211,28 @@ class _StopWordsWrapper(object):
 
         self.stop_words = stop_words  # list of stop words
 
+        self.name = self.model_dir / (str(name) + '.pkl')
 
-        self.name = os.path.join(self.model_dir, str(name) + '.pkl')
-
-        dump(self.stop_words, self.name)
+        dump(self.stop_words, str(self.name))
 
     def load(self, name):
         """Retrive stop words specified by a name
         """
-        self.name = os.path.join(self.model_dir, str(name) + '.pkl')
-        self.stop_words = load(self.name)
+        self.name = self.model_dir / (str(name) + '.pkl')
+        self.stop_words = load(str(self.name))
         return (self.stop_words)
 
     def delete(self, name):
         """Delete stop words specified by a name
         """
-        if os.path.exists(os.path.join(self.model_dir, str(name) + '.pkl')):
-            os.remove(os.path.join(self.model_dir, str(name) + '.pkl'))
+        if (self.model_dir / (str(name) + '.pkl')).exists():
+            (self.model_dir / (str(name) + '.pkl')).unlink()
 
     def __contains__(self, name):
         """ Check if a given stop words set exists """
-        return os.path.exists(os.path.join(self.model_dir, str(name) + '.pkl'))
+        return (self.model_dir / (str(name) + '.pkl')).exists()
 
     def list(self):
         """ Returns a list of exiting stop-words """
-        return [os.splitext(el)[0] for el in  os.listdir(self.model_dir)]
-
-
-
+        return [os.splitext(el)[0] for el in
+                os.listdir(str(self.model_dir))]

--- a/freediscovery/tests/test_base.py
+++ b/freediscovery/tests/test_base.py
@@ -7,10 +7,8 @@ from __future__ import unicode_literals
 
 
 import os.path
-from unittest import SkipTest
 import warnings
 
-import numpy as np
 from numpy.testing import (assert_allclose, assert_equal,
                            assert_array_less)
 
@@ -21,23 +19,23 @@ from .run_suite import check_cache
 
 
 def test_split_path():
-    assert _split_path('abc/test4') ==  ['abc', 'test4']
-    assert _split_path('abc/test4/') ==  ['abc', 'test4']
-    if os.name == 'nt': # on windows
-        assert _split_path('C:\\abc\\test4') ==  ["C:\\", 'abc', 'test4']
-        assert _split_path('C:\\abc\\test4\\') ==  ["C:\\", 'abc', 'test4']
-        assert _split_path('/test/test4') ==  ['\\', 'test', 'test4']
+    assert _split_path('abc/test4') == ['abc', 'test4']
+    assert _split_path('abc/test4/') == ['abc', 'test4']
+    if os.name == 'nt':  # on windows
+        assert _split_path('C:\\abc\\test4') == ["C:\\", 'abc', 'test4']
+        assert _split_path('C:\\abc\\test4\\') == ["C:\\", 'abc', 'test4']
+        assert _split_path('/test/test4') == ['\\', 'test', 'test4']
     else:
-        assert _split_path('/test/test4') ==  ['/', 'test', 'test4']
+        assert _split_path('/test/test4') == ['/', 'test', 'test4']
         # this raises an error on windows for some reason
-        assert _split_path('//abc/test4/') ==  ["//", 'abc', 'test4']
+        assert _split_path('//abc/test4/') == ["//", 'abc', 'test4']
 
 
 def test_normalize_cachedir():
     _normalize_cachedir = PipelineFinder._normalize_cachedir
 
-    assert _normalize_cachedir('/tmp/') == os.path.normpath('/tmp/ediscovery_cache')
-    assert _normalize_cachedir('/tmp/ediscovery_cache') == os.path.normpath('/tmp/ediscovery_cache')
+    assert str(_normalize_cachedir('/tmp/')) == os.path.normpath('/tmp/ediscovery_cache')
+    assert str(_normalize_cachedir('/tmp/ediscovery_cache')) == os.path.normpath('/tmp/ediscovery_cache')
 
 
 @pytest.yield_fixture(autouse=True, scope='session')

--- a/freediscovery/tests/test_categorize.py
+++ b/freediscovery/tests/test_categorize.py
@@ -32,7 +32,8 @@ EPSILON = 1e-4
 data_dir = os.path.join(basename, "..", "data", "ds_001", "raw")
 
 fe = FeatureVectorizer(cache_dir=cache_dir)
-vect_uuid = fe.preprocess(data_dir, file_pattern='.*\d.txt')
+vect_uuid = fe.setup()
+fe.ingest(data_dir, file_pattern='.*\d.txt')
 fe.transform()
 
 

--- a/freediscovery/tests/test_categorize.py
+++ b/freediscovery/tests/test_categorize.py
@@ -278,7 +278,7 @@ def test_pipeline(n_steps):
             pf.parent.parent.parent
 
         for estimator_type, mid in pf.items():
-            path = pf.get_path(mid, absolute=False)
+            path = str(pf.get_path(mid, absolute=False))
             if estimator_type == 'vectorizer':
                 assert re.match('ediscovery_cache.*', path)
             elif estimator_type == 'lsi':

--- a/freediscovery/tests/test_categorize.py
+++ b/freediscovery/tests/test_categorize.py
@@ -34,7 +34,6 @@ data_dir = os.path.join(basename, "..", "data", "ds_001", "raw")
 fe = FeatureVectorizer(cache_dir=cache_dir)
 vect_uuid = fe.setup()
 fe.ingest(data_dir, file_pattern='.*\d.txt')
-fe.transform()
 
 
 lsi = _LSIWrapper(cache_dir=cache_dir, parent_id=vect_uuid)

--- a/freediscovery/tests/test_cluster.py
+++ b/freediscovery/tests/test_cluster.py
@@ -29,7 +29,6 @@ def fd_setup():
                     stop_words='english',
                     min_df=0.1, max_df=0.9)
     fe.ingest(data_dir, file_pattern='.*\d.txt')
-    fe.transform()
 
     lsi = _LSIWrapper(cache_dir=cache_dir, parent_id=dsid)
     lsi.fit_transform(n_components=6)

--- a/freediscovery/tests/test_cluster.py
+++ b/freediscovery/tests/test_cluster.py
@@ -25,10 +25,10 @@ def fd_setup():
     data_dir = os.path.join(basename, "..", "data", "ds_001", "raw")
     n_features = 110000
     fe = FeatureVectorizer(cache_dir=cache_dir)
-    dsid = fe.preprocess(data_dir, file_pattern='.*\d.txt',
-                         n_features=n_features, use_hashing=False,
-                         stop_words='english',
-                         min_df=0.1, max_df=0.9)
+    dsid = fe.setup(n_features=n_features, use_hashing=False,
+                    stop_words='english',
+                    min_df=0.1, max_df=0.9)
+    fe.ingest(data_dir, file_pattern='.*\d.txt')
     fe.transform()
 
     lsi = _LSIWrapper(cache_dir=cache_dir, parent_id=dsid)

--- a/freediscovery/tests/test_datasets.py
+++ b/freediscovery/tests/test_datasets.py
@@ -1,9 +1,5 @@
-#!/usr/bin/python
 # -*- coding: utf-8 -*-
 
-import os.path
-import numpy as np
-from numpy.testing import assert_allclose, assert_equal
 import pytest
 import pandas as pd
 
@@ -11,19 +7,18 @@ from .run_suite import check_cache
 from ..utils import dict2type
 
 from freediscovery.datasets import load_dataset
-from unittest import SkipTest
-import json
 
 cache_dir = check_cache()
 
-@pytest.mark.parametrize('name', ['20newsgroups_micro'])#, 'treclegal09_2k_subset'])
-def test_load_20newsgoups_dataset(name):
-    md, training_set, dataset = load_dataset(name, force=True, cache_dir=cache_dir)
 
-    response_ref = { "document_id": 'int',
-                     "file_path": "str",
-                     "internal_id": "int"
-                     }
+@pytest.mark.parametrize('name', ['20newsgroups_micro'])
+def test_load_20newsgoups_dataset(name):
+    md, training_set, dataset = load_dataset(name, force=True,
+                                             cache_dir=cache_dir)
+
+    response_ref = {"document_id": 'int',
+                    "file_path": "str",
+                    "internal_id": "int"}
     if '20newsgroups' in name or 'treclegal09' in name:
         response_ref["category"] = "str"
 
@@ -45,7 +40,7 @@ def test_load_20newsgoups_dataset(name):
 
         for resp in [training_set, dataset]:
 
-            assert dict2type(resp[0]) ==  response_ref
+            assert dict2type(resp[0]) == response_ref
             result_fields = list(set([el['category'] for el in resp]))
 
             # the opposite if not always true (e.g. for small training sets)
@@ -59,18 +54,10 @@ def test_load_20newsgoups_dataset(name):
                 assert dataset.shape[0] == 12
             elif categories_sel == categories:
                 assert dataset.shape[0] == 2465
-                assert (training_set.category=='positive').sum() == 5
+                assert (training_set.category == 'positive').sum() == 5
         elif name == '20newsgroups_micro':
             if categories_sel == ['comp.graphics']:
                 assert dataset.shape[0] == 3
             elif categories_sel == categories:
                 assert dataset.shape[0] == 7
                 assert training_set.shape[0] == 4
-
-
-
-
-
-
-
-

--- a/freediscovery/tests/test_dupdetect.py
+++ b/freediscovery/tests/test_dupdetect.py
@@ -52,7 +52,6 @@ def fd_setup(**fe_options):
                     stop_words='english',
                     **fe_options)
     fe.ingest(data_dir, file_pattern='.*\d.txt')
-    fe.transform()
     return cache_dir, uuid, fe.filenames_, fe
 
 

--- a/freediscovery/tests/test_dupdetect.py
+++ b/freediscovery/tests/test_dupdetect.py
@@ -48,10 +48,10 @@ def fd_setup(**fe_options):
     data_dir = os.path.join(basename, "..", "data", "ds_001", "raw")
     n_features = 110000
     fe = FeatureVectorizer(cache_dir=cache_dir)
-    uuid = fe.preprocess(data_dir, file_pattern='.*\d.txt',
-                         n_features=n_features, use_hashing=True,
-                         stop_words='english',
-                         **fe_options)
+    uuid = fe.setup(n_features=n_features, use_hashing=True,
+                    stop_words='english',
+                    **fe_options)
+    fe.ingest(data_dir, file_pattern='.*\d.txt')
     fe.transform()
     return cache_dir, uuid, fe.filenames_, fe
 

--- a/freediscovery/tests/test_ingestion.py
+++ b/freediscovery/tests/test_ingestion.py
@@ -243,6 +243,7 @@ def test_ingestion_metadata(n_fields):
         metadata.append(el)
 
     dbi = DocumentIndex.from_list(metadata)
+    dbi._make_relative_paths()
     data_dir_res, filenames, db = dbi.data_dir, dbi.filenames_, dbi.data
 
     if n_fields in [1, 2]:

--- a/freediscovery/tests/test_ingestion.py
+++ b/freediscovery/tests/test_ingestion.py
@@ -26,6 +26,7 @@ fnames_in_abs = [os.path.join(data_dir, el) for el in fnames_in]
 
 def test_ingestion_base_dir():
     dbi = DocumentIndex.from_folder(data_dir)
+    dbi._make_relative_paths()
     data_dir_res, filenames, db = dbi.data_dir, dbi.filenames_, dbi.data
     assert data_dir_res == os.path.normpath(data_dir)
     assert_array_equal(db.columns.values, ['file_path', 'internal_id', 'document_id'])
@@ -38,6 +39,7 @@ def test_ingestion_base_dir():
 
 def test_search_2fields():
     dbi = DocumentIndex.from_folder(data_dir)
+    dbi._make_relative_paths()
 
     query = pd.DataFrame([{'internal_id': 3},
                           {'internal_id': 1},
@@ -65,6 +67,7 @@ def test_search_2fields():
 
     query = pd.DataFrame([{'file_path': "0.7.6.28637.txt"},
                           {'file_path': "0.7.47.117435.txt"}])
+    del dbi.data['file_path']
     sres = dbi.search(query)
     query_res = [dbi.data.file_path.values.tolist().index(el)
                  for el in query.file_path.values]
@@ -139,6 +142,7 @@ def test_search_document_id():
         el['internal_id'] = idx
 
     dbi = DocumentIndex.from_list(md)
+    dbi._make_relative_paths()
     query = pd.DataFrame([{'internal_id': 1},
                           {'internal_id': 2},
                           {'internal_id': 1}])
@@ -173,6 +177,8 @@ def test_search_document_rendition_id():
 
     # can always index with internal_id
     dbi = DocumentIndex.from_list(md)
+    dbi._make_relative_paths()
+
     query = pd.DataFrame([{'internal_id': 1},
                           {'internal_id': 2},
                           {'internal_id': 1}])

--- a/freediscovery/tests/test_integration.py
+++ b/freediscovery/tests/test_integration.py
@@ -38,8 +38,8 @@ def test_features_hashing(use_hashing, use_lsi, method):
     n_features = 20000
 
     fe = FeatureVectorizer(cache_dir=cache_dir)
-    uuid = fe.preprocess(data_dir, file_pattern='.*\d.txt',
-                         n_features=n_features, use_hashing=use_hashing)
+    uuid = fe.setup(n_features=n_features, use_hashing=use_hashing)
+    fe.ingest(data_dir, file_pattern='.*\d.txt')
     fe.transform()
 
     ground_truth = parse_ground_truth_file(os.path.join(data_dir,

--- a/freediscovery/tests/test_integration.py
+++ b/freediscovery/tests/test_integration.py
@@ -40,7 +40,6 @@ def test_features_hashing(use_hashing, use_lsi, method):
     fe = FeatureVectorizer(cache_dir=cache_dir)
     uuid = fe.setup(n_features=n_features, use_hashing=use_hashing)
     fe.ingest(data_dir, file_pattern='.*\d.txt')
-    fe.transform()
 
     ground_truth = parse_ground_truth_file(os.path.join(data_dir,
                                            "..", "ground_truth_file.txt"))

--- a/freediscovery/tests/test_lsi.py
+++ b/freediscovery/tests/test_lsi.py
@@ -22,7 +22,8 @@ def test_lsi():
     n_components = 5
 
     fe = FeatureVectorizer(cache_dir=cache_dir)
-    uuid = fe.preprocess(data_dir, file_pattern='.*\d.txt')
+    uuid = fe.setup()
+    fe.ingest(data_dir, file_pattern='.*\d.txt')
     fe.transform()
 
     lsi = _LSIWrapper(cache_dir=cache_dir, parent_id=uuid)
@@ -55,7 +56,8 @@ def test_lsi_append_documents():
     cache_dir = check_cache()
 
     fe = FeatureVectorizer(cache_dir=cache_dir)
-    uuid = fe.preprocess(data_dir)
+    uuid = fe.setup()
+    fe.ingest(data_dir)
     fe.transform()
 
     lsi = _LSIWrapper(cache_dir=cache_dir, parent_id=uuid)
@@ -79,7 +81,8 @@ def test_lsi_remove_documents():
     cache_dir = check_cache()
 
     fe = FeatureVectorizer(cache_dir=cache_dir)
-    uuid = fe.preprocess(data_dir)
+    uuid = fe.setup()
+    fe.ingest(data_dir)
     fe.transform()
 
     lsi = _LSIWrapper(cache_dir=cache_dir, parent_id=uuid)

--- a/freediscovery/tests/test_lsi.py
+++ b/freediscovery/tests/test_lsi.py
@@ -24,7 +24,6 @@ def test_lsi():
     fe = FeatureVectorizer(cache_dir=cache_dir)
     uuid = fe.setup()
     fe.ingest(data_dir, file_pattern='.*\d.txt')
-    fe.transform()
 
     lsi = _LSIWrapper(cache_dir=cache_dir, parent_id=uuid)
     lsi_res, exp_var = lsi.fit_transform(n_components=n_components)
@@ -58,7 +57,6 @@ def test_lsi_append_documents():
     fe = FeatureVectorizer(cache_dir=cache_dir)
     uuid = fe.setup()
     fe.ingest(data_dir)
-    fe.transform()
 
     lsi = _LSIWrapper(cache_dir=cache_dir, parent_id=uuid)
     lsi_res, exp_var = lsi.fit_transform(n_components=2)
@@ -83,7 +81,6 @@ def test_lsi_remove_documents():
     fe = FeatureVectorizer(cache_dir=cache_dir)
     uuid = fe.setup()
     fe.ingest(data_dir)
-    fe.transform()
 
     lsi = _LSIWrapper(cache_dir=cache_dir, parent_id=uuid)
     lsi_res, exp_var = lsi.fit_transform(n_components=2)

--- a/freediscovery/tests/test_search.py
+++ b/freediscovery/tests/test_search.py
@@ -73,7 +73,6 @@ def test_search_wrapper(kind):
     fe = FeatureVectorizer(cache_dir=cache_dir)
     vect_uuid = fe.setup()
     fe.ingest(data_dir, file_pattern='.*\d.txt')
-    fe.transform()
 
     if kind == 'semantic':
         lsi = _LSIWrapper(cache_dir=cache_dir, parent_id=vect_uuid)

--- a/freediscovery/tests/test_search.py
+++ b/freediscovery/tests/test_search.py
@@ -71,7 +71,8 @@ def test_search_wrapper(kind):
     # check for syntax errors etc in the wrapper
 
     fe = FeatureVectorizer(cache_dir=cache_dir)
-    vect_uuid = fe.preprocess(data_dir, file_pattern='.*\d.txt')
+    vect_uuid = fe.setup()
+    fe.ingest(data_dir, file_pattern='.*\d.txt')
     fe.transform()
 
     if kind == 'semantic':

--- a/freediscovery/tests/test_text.py
+++ b/freediscovery/tests/test_text.py
@@ -30,9 +30,9 @@ def test_feature_extraction_tokenization(analyzer, ngram_range, use_hashing):
     use_hashing = (use_hashing == 'hashed')
 
     fe = FeatureVectorizer(cache_dir=cache_dir)
-    uuid = fe.preprocess(data_dir, file_pattern='.*\d.txt',
-                         analyzer=analyzer, ngram_range=ngram_range,
-                         use_hashing=use_hashing)
+    uuid = fe.setup(analyzer=analyzer, ngram_range=ngram_range,
+                    use_hashing=use_hashing)
+    fe.ingest(data_dir, file_pattern='.*\d.txt')
     fe.transform()
 
     res2 = fe._load_features(uuid)
@@ -60,9 +60,9 @@ def test_feature_extraction_weighting(use_idf, sublinear_tf, binary,
     use_hashing = (use_hashing == 'hashed')
 
     fe = FeatureVectorizer(cache_dir=cache_dir)
-    uuid = fe.preprocess(data_dir, file_pattern='.*\d.txt',
-                         use_idf=use_idf, binary=binary,
-                         use_hashing=use_hashing, sublinear_tf=sublinear_tf)
+    uuid = fe.setup(use_idf=use_idf, binary=binary,
+                    use_hashing=use_hashing, sublinear_tf=sublinear_tf)
+    fe.ingest(data_dir, file_pattern='.*\d.txt')
     fe.transform()
 
     res2 = fe._load_features(uuid)
@@ -86,9 +86,9 @@ def test_feature_extraction_nfeatures(n_features, use_idf, use_hashing):
     use_idf = (use_idf == 'IDF')
 
     fe = FeatureVectorizer(cache_dir=cache_dir)
-    uuid = fe.preprocess(data_dir, file_pattern='.*\d.txt',
-                         n_features=n_features,
-                         use_idf=use_idf, use_hashing=use_hashing)
+    uuid = fe.setup(n_features=n_features,
+                    use_idf=use_idf, use_hashing=use_hashing)
+    fe.ingest(data_dir, file_pattern='.*\d.txt')
     fe.transform()
 
     res2 = fe._load_features(uuid)
@@ -107,8 +107,8 @@ def test_search_filenames(use_hashing):
     cache_dir = check_cache()
 
     fe = FeatureVectorizer(cache_dir=cache_dir)
-    uuid = fe.preprocess(data_dir, file_pattern='.*\d.txt',
-                         use_hashing=use_hashing)
+    uuid = fe.setup(use_hashing=use_hashing)
+    fe.ingest(data_dir, file_pattern='.*\d.txt')
     fe.transform()
 
     assert fe.db_ is not None
@@ -139,14 +139,15 @@ def test_df_filtering(use_hashing, min_df, max_df):
     cache_dir = check_cache()
 
     fe = FeatureVectorizer(cache_dir=cache_dir)
-    uuid = fe.preprocess(data_dir, use_hashing=use_hashing,
-                         min_df=min_df, max_df=max_df)
+    uuid = fe.setup(min_df=min_df, max_df=max_df, use_hashing=use_hashing)
+    fe.ingest(data_dir)
     fe.transform()
 
     X = fe._load_features(uuid)
 
     fe2 = FeatureVectorizer(cache_dir=cache_dir)
-    uuid2 = fe2.preprocess(data_dir, use_hashing=use_hashing)
+    uuid2 = fe2.setup(use_hashing=use_hashing)
+    fe2.ingest(data_dir)
     fe2.transform()
 
     X2 = fe2._load_features(uuid2)
@@ -165,7 +166,8 @@ def test_append_documents():
     cache_dir = check_cache()
 
     fe = FeatureVectorizer(cache_dir=cache_dir)
-    uuid = fe.preprocess(data_dir)
+    uuid = fe.setup()
+    fe.ingest(data_dir)
     fe.transform()
 
     X = fe._load_features(uuid)
@@ -201,7 +203,8 @@ def test_remove_documents():
     cache_dir = check_cache()
 
     fe = FeatureVectorizer(cache_dir=cache_dir)
-    uuid = fe.preprocess(data_dir)
+    uuid = fe.setup()
+    fe.ingest(data_dir)
     fe.transform()
 
     X = fe._load_features(uuid)
@@ -238,8 +241,8 @@ def test_sampling_filenames():
     fe = FeatureVectorizer(cache_dir=cache_dir)
     with pytest.warns(UserWarning):
         # there is a warning because we don't use norm='l2'
-        uuid = fe.preprocess(data_dir, file_pattern='.*\d.txt',
-                             use_hashing=True, **fe_pars)
+        uuid = fe.setup(use_hashing=True, **fe_pars)
+        fe.ingest(data_dir, file_pattern='.*\d.txt')
     fe.transform()
     X = fe._load_features(uuid)
 
@@ -313,8 +316,8 @@ def test_feature_extraction_cyrillic(use_hashing):
     use_hashing = (use_hashing == 'hashed')
 
     fe = FeatureVectorizer(cache_dir=cache_dir)
-    uuid = fe.preprocess(data_dir, file_pattern='.*\d.txt',
-                         use_hashing=use_hashing)
+    uuid = fe.setup(use_hashing=use_hashing)
+    fe.ingest(data_dir, file_pattern='.*\d.txt')
     fe.transform()
 
     res2 = fe._load_features(uuid)
@@ -337,7 +340,8 @@ def test_email_parsing():
     cache_dir = check_cache()
 
     fe = FeatureVectorizer(cache_dir=cache_dir)
-    uuid = fe.preprocess(data_dir)
+    uuid = fe.setup()
+    fe.ingest(data_dir)
     fe.transform()
 
     email_md = fe.parse_email_headers()

--- a/freediscovery/tests/test_text.py
+++ b/freediscovery/tests/test_text.py
@@ -357,3 +357,25 @@ def test_ingestion_batches():
     assert len(fe.filenames_) == 6*3
     X = fe._load_features()
     assert X.shape[0] == 6*3
+
+    with pytest.raises(ValueError):
+        fe.ingest(vectorize=True)  # already vectorized
+
+
+def test_ingestion_content():
+    dd = [{'document_id': 47,
+           'content': 'This is a test :$&'},
+          {'document_id': 99,
+           'content': 'Another test document!'}]
+    cache_dir = check_cache()
+
+    fe = FeatureVectorizer(cache_dir=cache_dir)
+    uuid = fe.setup()
+    fe.ingest(dataset_definition=dd, vectorize=True)
+    assert len(fe.filenames_) == 2
+    assert fe.filenames_[0] == '0_0.txt'
+    assert fe._load_features().shape[0] == 2
+    assert fe.db_.data.shape[0] == len(fe.filenames_)
+
+
+

--- a/freediscovery/tests/test_text.py
+++ b/freediscovery/tests/test_text.py
@@ -380,7 +380,7 @@ def test_ingestion_content():
 
     dd = []
     for idx, fname in enumerate(sorted(data_dir.glob('*txt'))):
-        with fname.open('rt') as fh:
+        with fname.open('rt', encoding='utf-8') as fh:
             dd.append({'document_id': idx + 19,
                        'content': fh.read()})
     cache_dir = check_cache()

--- a/freediscovery/tests/test_thread.py
+++ b/freediscovery/tests/test_thread.py
@@ -16,7 +16,8 @@ def test_threading():
     cache_dir = check_cache()
 
     fe = FeatureVectorizer(cache_dir=cache_dir)
-    uuid = fe.preprocess(data_dir=data_dir)
+    uuid = fe.setup()
+    fe.ingest(data_dir=data_dir)
     fe.transform()
     fe.parse_email_headers()
 

--- a/freediscovery/tests/test_thread.py
+++ b/freediscovery/tests/test_thread.py
@@ -18,7 +18,6 @@ def test_threading():
     fe = FeatureVectorizer(cache_dir=cache_dir)
     uuid = fe.setup()
     fe.ingest(data_dir=data_dir)
-    fe.transform()
     fe.parse_email_headers()
 
     cat = _EmailThreadingWrapper(cache_dir=cache_dir, parent_id=uuid)

--- a/freediscovery/text.py
+++ b/freediscovery/text.py
@@ -283,6 +283,8 @@ class FeatureVectorizer(object):
         vectorize : bool (default: True)
         """
         dsid_dir = self.cache_dir / self.dsid
+        if (dsid_dir / 'db').exists():
+            raise ValueError('Dataset already vectorized!')
         db_list = list(sorted(dsid_dir.glob('db*')))
         if len(db_list) == 0:
             internal_id_offset = -1
@@ -291,7 +293,7 @@ class FeatureVectorizer(object):
 
         if dataset_definition is not None:
             db = DocumentIndex.from_list(dataset_definition, data_dir,
-                                         internal_id_offset + 1)
+                                         internal_id_offset + 1, dsid_dir)
         elif data_dir is not None:
             db = DocumentIndex.from_folder(data_dir, file_pattern, dir_pattern,
                                            internal_id_offset + 1)


### PR DESCRIPTION
This PR,
 - adds the ability ingest documents when they are provided in the JSON request of `POST /api/v0/feature-extraction/{dsid}` under the `dataset_definition->content` field. Ingesting documents by batches is also supported.
 - refactors the data ingestion code to be more consistent 
     * the `pathlib` library from Python 3 is now used instead of `os.path` for most files/paths manipulations.