### PR TITLE
Added URL endpoint with server info

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -19,7 +19,7 @@ dependencies:
   override:
     - source build_tools/circle/install.sh
     - source activate testenv && freediscovery run -y --cache-dir ../freediscovery_shared:
-       background: true
+        background: true
     - sleep 20
     # The pipefail is requested to propagate exit code
     - set -o pipefail && cd doc && source activate testenv && make html 2>&1 | tee ~/log.txt

--- a/freediscovery/__main__.py
+++ b/freediscovery/__main__.py
@@ -26,10 +26,9 @@ def _parse_cache_dir(cache_dir):
 
 
 def _run(args):
-    df_config = vars(args)
-    del df_config['func']
-    del df_config['yes']
-
+    df_config = vars(args).copy()
+    df_config.pop('func', None)
+    df_config.pop('yes', None)
 
     cache_dir = _parse_cache_dir(args.cache_dir)
     cache_dir = os.path.normpath(os.path.abspath(cache_dir))
@@ -51,6 +50,7 @@ def _run(args):
     log_fname = os.path.normpath(os.path.abspath(log_fname))
 
     df_config['log_file'] = log_fname
+    df_config['n_workers'] = df_config.pop('n', None)
 
     # redirect stdout / stderr to a file
     sys.stdout = _TeeLogger(log_fname)

--- a/freediscovery/__main__.py
+++ b/freediscovery/__main__.py
@@ -26,6 +26,11 @@ def _parse_cache_dir(cache_dir):
 
 
 def _run(args):
+    df_config = vars(args)
+    del df_config['func']
+    del df_config['yes']
+
+
     cache_dir = _parse_cache_dir(args.cache_dir)
     cache_dir = os.path.normpath(os.path.abspath(cache_dir))
     if not os.path.exists(cache_dir):
@@ -40,8 +45,12 @@ def _run(args):
             return
     else:
         _cache_dir_exists = True
+
+    df_config['cache_dir'] = cache_dir
     log_fname = args.log_file.replace('${CACHE_DIR}', cache_dir)
     log_fname = os.path.normpath(os.path.abspath(log_fname))
+
+    df_config['log_file'] = log_fname
 
     # redirect stdout / stderr to a file
     sys.stdout = _TeeLogger(log_fname)
@@ -54,7 +63,7 @@ def _run(args):
                                          'EXISTING' if _cache_dir_exists else 'NEW'))
     print(' * LOG_FILE: {}'.format(log_fname))
 
-    app = fd_app(cache_dir)
+    app = fd_app(cache_dir, df_config)
     if args.hostname == '0.0.0.0':
         print(' * WARNING: running the server on hostname 0.0.0.0 '
               '(accessible from any IP address). Please make sure '
@@ -78,6 +87,7 @@ def _run(args):
             parent_pid = os.getpid()
             print(' * Server: gunicorn with {} workers'.format(args.n))
             print(' * Running on http://{}/ (Press CTRL+C to quit)'.format(options['bind']))
+            df_config['server'] = 'gunicorn'
             GunicornApplication(app, options).run()
             return
         except SystemExit:
@@ -95,6 +105,7 @@ def _run(args):
     # run the built-in server
     print(' * Server: flask (Werkzeug) threaded')
 
+    df_config['server'] = 'werkzeug'
     app.run(debug=False, host=args.hostname,
             processes=1, threaded=True,
             port=args.port, use_reloader=False)

--- a/freediscovery/server/info.py
+++ b/freediscovery/server/info.py
@@ -1,0 +1,26 @@
+
+import sys
+
+from flask_apispec import (marshal_with,
+                           MethodResource as Resource)
+from flask_apispec.annotations import doc
+
+from .._version import __version__
+
+# =========================================================================== #
+#                        Server info                                          #
+# =========================================================================== #
+
+
+class ServerInfoApi(Resource):
+
+    @doc(description="Return FreeDiscovery server information "
+                     " (versions, etc).")
+    def get(self):
+        out = {'version': {},
+               'env': {}}
+
+        out['version']['number'] = __version__
+        out['env']['python_version'] = sys.version
+        out['config'] = self._fd_config
+        return out

--- a/freediscovery/server/info.py
+++ b/freediscovery/server/info.py
@@ -4,7 +4,9 @@ import sys
 from flask_apispec import (marshal_with,
                            MethodResource as Resource)
 from flask_apispec.annotations import doc
+from webargs import fields as wfields
 
+from webargs.core import argmap2schema
 from .._version import __version__
 
 # =========================================================================== #
@@ -16,6 +18,17 @@ class ServerInfoApi(Resource):
 
     @doc(description="Return FreeDiscovery server information "
                      " (versions, etc).")
+    @marshal_with(argmap2schema(
+                  {'version': wfields.Nested({'number': wfields.Str()}),
+                   'env': wfields.Nested({'python_version': wfields.Str()}),
+                   'config': wfields.Nested({'cache_dir': wfields.Str(),
+                                             'debug': wfields.Boolean(),
+                                             'hostname': wfields.Str(),
+                                             'log_file': wfields.Str(),
+                                             'n_workers': wfields.Int(),
+                                             'port': wfields.Int(),
+                                             'server': wfields.Str()})
+                   }))
     def get(self):
         out = {'version': {},
                'env': {}}

--- a/freediscovery/server/tests/test_various.py
+++ b/freediscovery/server/tests/test_various.py
@@ -44,3 +44,11 @@ def test_openapi_specs(app):
     data = app.get_check('/openapi-specs.json')
     assert data['swagger'] == '2.0'
 
+
+def test_version(app):
+    data = app.get_check('/')
+    assert dict2type(data) == {'version': {'number': 'str'},
+                               'env': {'python_version': 'str'},
+                               'config': 'NoneType'}
+
+


### PR DESCRIPTION
This adds a root endpoint with server information. Running `curl -X GET http://localhost:5001/` would produce something similar to,
```
{
  "config": {
    "cache_dir": "/home/user/freediscovery_shared", 
    "debug": false, 
    "hostname": "0.0.0.0", 
    "log_file": "/home/user/freediscovery_shared/freediscovery-backend.log", 
    "n_workers": 6, 
    "port": 5001, 
    "server": "werkzeug"
  }, 
  "env": {
    "python_version": "3.6.1 |Continuum Analytics, Inc.| (default, May 11 2017, 13:09:58) \n[GCC 4.4.7 20120313 (Red Hat 4.4.7-1)]"
  }, 
  "version": {
    "number": "1.1.0"
  }
}
```

