### PR TITLE
Generating `document_id` from document filenames 

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,0 +1,1 @@
+comment: false

--- a/.coveragerc
+++ b/.coveragerc
@@ -3,3 +3,4 @@ omit =
    freediscovery/tests/*
    freediscovery/server/tests/*
    freediscovery/externals/*
+   freediscovery/__main__.py

--- a/freediscovery/server/resources.py
+++ b/freediscovery/server/resources.py
@@ -172,10 +172,12 @@ class FeaturesApiElement(Resource):
           - `data_dir`: [optional] relative path to the directory with the input files. Either `data_dir` or `dataset_definition` must be provided.
           - `dataset_definition`: [optional] a list of dictionaries `[{'file_path': <str>, 'content': <str>, 'document_id': <int>, 'rendition_id': <int>}, ...]` where `document_id` and `rendition_id` are optional, while either `file_path` or `content` field must be provided. 
           - `vectorize`: [optional] this option can be used to ingest the dataset_definition in batches (optionally with document content), then make one final call to vectorize all sent documents (bool, default: True)
+          - `document_id_generator`: [optional] if the `document_id` is not provided, this specifies how it is generated. If `indexed_file_path` the `document_id` is given by the index of the sorted `file_path`, otherwise if `infer_file_path` the `document_id` is inferred from the `file_path` strings, removing all non digit characters. In this second case, the `file_path` must contain a unique numeric ID (default: `indexed_file_path`)
          """))
     @use_args({"data_dir":  wfields.Str(),
                "dataset_definition": wfields.Nested(_DatasetDefinition, many=True),
-               "vectorize": wfields.Bool(missing=True)})
+               "vectorize": wfields.Bool(missing=True),
+               "document_id_generator": wfields.Str(missing="indexed_file_path")})
     @marshal_with(IDSchema())
     def post(self, dsid, **args):
         fe = FeatureVectorizer(self._cache_dir, dsid=dsid)

--- a/freediscovery/tests/test_ingestion.py
+++ b/freediscovery/tests/test_ingestion.py
@@ -6,7 +6,7 @@ from pandas.util.testing import assert_frame_equal
 import pytest
 import pandas as pd
 
-from freediscovery.ingestion import DocumentIndex
+from freediscovery.ingestion import DocumentIndex, _infer_document_id_from_path
 from .run_suite import check_cache
 from freediscovery.exceptions import (NotFound)
 
@@ -257,3 +257,20 @@ def test_ingestion_metadata(n_fields):
                         for el in filenames],
                        [os.path.join(data_dir_res, el)
                         for el in db.file_path.values])
+
+
+def test_infer_document_id_from_path():
+    file_path = ['test/file1.txt', 'test3/file2.txt', 'test4/file4.txt']
+
+    document_id = _infer_document_id_from_path(file_path)
+    assert_array_equal(document_id, [1, 2, 4])
+
+    file_path = ['test/file.txt', 'test3/file2.txt', 'test4/file4.txt']
+
+    document_id = _infer_document_id_from_path(file_path)
+    assert document_id is None
+
+    file_path = ['test/file1.txt', 'test3/file1.txt', 'test4/file4.txt']
+
+    document_id = _infer_document_id_from_path(file_path)
+    assert document_id is None

--- a/freediscovery/text.py
+++ b/freediscovery/text.py
@@ -270,7 +270,8 @@ class FeatureVectorizer(object):
         return dsid
 
     def ingest(self, data_dir=None, file_pattern='.*', dir_pattern='.*',
-               dataset_definition=None, vectorize=True):
+               dataset_definition=None, vectorize=True,
+               document_id_generator='indexed_file_path'):
         """Perform data ingestion
 
         Parameters
@@ -296,10 +297,12 @@ class FeatureVectorizer(object):
 
         if dataset_definition is not None:
             db = DocumentIndex.from_list(dataset_definition, data_dir,
-                                         internal_id_offset + 1, dsid_dir)
+                                         internal_id_offset + 1, dsid_dir,
+                                         document_id_generator=document_id_generator)
         elif data_dir is not None:
             db = DocumentIndex.from_folder(data_dir, file_pattern, dir_pattern,
-                                           internal_id_offset + 1)
+                                           internal_id_offset + 1,
+                                           document_id_generator=document_id_generator)
         else:
             db = None
 


### PR DESCRIPTION
This PR adds an optional parameter `document_id_generator` for the

`POST /api/v0/feature-extraction/{dataset_id}'` endpoint. When set to `infer_file_path` the system will attempt to generate a meaningful numeric `document_id` from the document file name. 

This is mostly used to make examples more comprehensible.