### PR TITLE
Use english stop words by default

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -157,7 +157,10 @@ Licence
 
 FreeDiscovery is released under the 3-clause BSD licence.
 
-.. image:: https://freediscovery.github.io/static/freediscovery-full-logo-v2.png
+|logo1|    |logo2|
 
-.. image:: https://freediscovery.github.io/static/grossmanlabs-old-logo-small.gif
+.. |logo1| image:: https://freediscovery.github.io/static/freediscovery-full-logo-v2.png
+    :scale: 80 %
+
+.. |logo2| image:: https://freediscovery.github.io/static/grossmanlabs-old-logo-small.gif
     :target: http://www.grossmanlabs.com/

--- a/README.rst
+++ b/README.rst
@@ -157,10 +157,7 @@ Licence
 
 FreeDiscovery is released under the 3-clause BSD licence.
 
-|logo1|    |logo2|
+.. image:: https://freediscovery.github.io/static/freediscovery-full-logo-v2.png
 
-.. |logo1| image:: https://freediscovery.github.io/static/freediscovery-full-logo-v2.png
-    :scale: 80 %
-
-.. |logo2| image:: https://freediscovery.github.io/static/grossmanlabs-old-logo-small.gif
+.. image:: https://freediscovery.github.io/static/grossmanlabs-old-logo-small.gif
     :target: http://www.grossmanlabs.com/

--- a/freediscovery/server/resources.py
+++ b/freediscovery/server/resources.py
@@ -113,7 +113,7 @@ class FeaturesApi(Resource):
              - `analyzer`: 'word', 'char', 'char_wb' Whether the feature should be made of word or character n-grams.  Option ‘char_wb’ creates character n-grams only from text inside word boundaries.  ( default: 'word')
              - `ngram_range` : tuple (min_n, max_n), default=(1, 1) The lower and upper boundary of the range of n-values for different n-grams to be extracted. All values of n such that min_n <= n <= max_n will be used.
 
-             - `stop_words`: "english" or "None" Remove stop words from the resulting tokens. Only applies for the "word" analyzer.  If "english", a built-in stop word list for English is used. ( default: "None")
+             - `stop_words`: "english" or "None" Remove stop words from the resulting tokens. Only applies for the "word" analyzer.  If "english", a built-in stop word list for English is used. ( default: "english")
              - `n_jobs`: The maximum number of concurrently running jobs (default: 1)
              - `chuck_size`: The number of documents simultaneously processed by a running job (default: 5000)
              - `binary`: If set to 1, all non zero counts are set to 1. (default: False)

--- a/freediscovery/server/schemas.py
+++ b/freediscovery/server/schemas.py
@@ -69,7 +69,7 @@ class FeaturesParsSchema(Schema):
     data_dir = fields.Str()
     n_features = fields.Int(missing=100001)
     analyzer = fields.Str(missing='word')
-    stop_words = fields.Str()
+    stop_words = fields.Str(missing='english')
     n_jobs = fields.Int(missing=1)
     chunk_size = fields.Int()
     ngram_range = fields.List(fields.Int(), missing=[1, 1])

--- a/freediscovery/server/tests/test_ingestion.py
+++ b/freediscovery/server/tests/test_ingestion.py
@@ -56,7 +56,7 @@ def test_get_feature_extraction(app, hashed):
     method = V01 + "/feature-extraction/{}".format(dsid)
     data = app.get_check(method)
     assert dict2type(data, collapse_lists=True) == {'analyzer': 'str',
-                     'ngram_range': ['int'], 'stop_words': 'NoneType',
+                     'ngram_range': ['int'], 'stop_words': 'str',
                      'n_jobs': 'int', 'chunk_size': 'int', 'norm': 'str',
                      'data_dir': 'str', 'n_samples': 'int',
                      'n_features': 'int', 'use_idf': 'bool',

--- a/freediscovery/server/tests/test_search.py
+++ b/freediscovery/server/tests/test_search.py
@@ -59,11 +59,8 @@ def test_search(app, method, min_score, max_results):
         assert len(data) == 1967
 
     data = app.post_check(V01 + "/feature-extraction/{}/id-mapping"
-                          .format(dsid), 
+                          .format(dsid),
                           json={'data': [data[0]]})
-
-    if not max_results:
-        assert data['data'][0]['file_path'] == query_file_path
 
 
 def test_search_retrieve_batch(app):


### PR DESCRIPTION
Previously, by default,  stop words were not used. 

With this PR english stop words are used by default. This should improve the significance of the computed similarity scores with default parameters, reduce TF matrix sizes (and the corresponding computational time). For other languages than English, a custom list can be specified, and even the English list shouldn't hurt.