### PR TITLE
Mechanism for preprocessing steps

### DIFF
--- a/benchmarks/ingestion.py
+++ b/benchmarks/ingestion.py
@@ -13,6 +13,7 @@ import os.path
 from multiprocessing import Process
 import requests
 import pandas as pd
+import sys
 
 pd.options.display.float_format = '{:,.3f}'.format
 pd.options.display.expand_frame_repr = False
@@ -22,122 +23,69 @@ dataset_name = "treclegal09_37k_subset"     # see list of available datasets
 BASE_URL = "http://localhost:5001/api/v0"  # FreeDiscovery server URL
 
 ingestion_method = 'file_path'
-#ingestion_method = 'content'
 
-if __name__ == '__main__':
 
-    print(" 0. Load the example dataset")
-    url = BASE_URL + '/example-dataset/{}'.format(dataset_name)
-    print(" GET", url)
-    input_ds = requests.get(url).json()
+print(" 0. Load the example dataset")
+url = BASE_URL + '/example-dataset/{}'.format(dataset_name)
+print(" GET", url)
+input_ds = requests.get(url).json()
 
-    data_dir = input_ds['metadata']['data_dir']
-    dataset_definition = []
-    for row in input_ds['dataset']:
-        dd_row = {'document_id': row['document_id']}
-        if ingestion_method == 'file_path':
-            dd_row['file_path'] = os.path.join(data_dir, row['file_path'])
-            dataset_definition.append(dd_row)
-        elif ingestion_method == 'content':
-            with Path(data_dir, row['file_path']).open('rt') as fh:
-                try:
-                    dd_row['content'] = fh.read()
-                    dataset_definition.append(dd_row)
-                except UnicodeDecodeError:
-                    print(Path(data_dir, row['file_path']), ' failed!')
-        else:
-            raise ValueError
-    # create a custom dataset definition for ingestion
+data_dir = input_ds['metadata']['data_dir']
+dataset_definition = []
+for row in input_ds['dataset']:
+    dd_row = {'document_id': row['document_id']}
+    if ingestion_method == 'file_path':
+        dd_row['file_path'] = os.path.join(data_dir, row['file_path'])
+        dataset_definition.append(dd_row)
+    elif ingestion_method == 'content':
+        with Path(data_dir, row['file_path']).open('rt') as fh:
+            try:
+                dd_row['content'] = fh.read()
+                dataset_definition.append(dd_row)
+            except UnicodeDecodeError:
+                print(Path(data_dir, row['file_path']), ' failed!')
+    else:
+        raise ValueError
+# create a custom dataset definition for ingestion
 
-    # 1. Feature extraction
+# 1. Feature extraction
 
-    print("\n1.a Load dataset and initalize feature extraction")
-    url = BASE_URL + '/feature-extraction'
-    print(" POST", url)
-    res = requests.post(url, json={'max_df': 0.6, 'preprocess': ['emails_ignore_header']}).json()
+print("\n1.a Load dataset and initalize feature extraction")
+url = BASE_URL + '/feature-extraction'
+print(" POST", url)
+res = requests.post(url, json={'max_df': 0.6, 'preprocess': ['emails_ignore_header']
+                              }).json()
 
-    dsid = res['id']
-    print("   => received {}".format(list(res.keys())))
-    print("   => dsid = {}".format(dsid))
+dsid = res['id']
+print("   => received {}".format(list(res.keys())))
+print("   => dsid = {}".format(dsid))
 
-    print("\n1.b Start feature extraction (in the background)")
+print("\n1.b Start feature extraction (in the background)")
 
-    # Make this call in a background process (there should be a better way of doing it)
-    url = BASE_URL+'/feature-extraction/{}'.format(dsid)
-    print(" POST", url)
-    t0 = time()
-    for i in range(0, len(dataset_definition), 8000):
-        res = requests.post(url, json={'dataset_definition': dataset_definition[i:i + 8000],
-                                       'vectorize': False})
+# Make this call in a background process (there should be a better way of doing it)
+url = BASE_URL+'/feature-extraction/{}'.format(dsid)
+print(" POST", url)
+t0 = time()
+for i in range(0, len(dataset_definition), 8000):
+    res = requests.post(url, json={'dataset_definition': dataset_definition[i:i + 8000],
+                                   'vectorize': False})
 
-    print('     ... files ingested in {:.1f} s'.format((time() - t0)))
-    t1 = time()
-    res = requests.post(url, json={'vectorize': True})
-    print('     ... files vectorized in {:.1f} s'.format((time() - t0)))
+print('     ... files ingested in {:.1f} s'.format((time() - t0)))
+t1 = time()
+res = requests.post(url, json={'vectorize': True})
+print('     ... files vectorized in {:.1f} s'.format((time() - t0)))
 
-    print("\n1.d. check the parameters of the extracted features")
-    url = BASE_URL + '/feature-extraction/{}'.format(dsid)
-    print(' GET', url)
-    res = requests.get(url).json()
+print("\n1.d. check the parameters of the extracted features")
+url = BASE_URL + '/feature-extraction/{}'.format(dsid)
+print(' GET', url)
+res = requests.get(url).json()
 
-    print('\n'.join(['     - {}: {}'.format(key, val)
-          for key, val in res.items() if "filenames" not in key]))
+print('\n'.join(['     - {}: {}'.format(key, val)
+      for key, val in res.items() if "filenames" not in key]))
 
-    # 3. Document categorization
 
-    print("\n3.a. Train the categorization model")
-    print("   {} positive, {} negative files".format(
-          pd.DataFrame(input_ds['training_set'])
-            .groupby('category').count()['document_id'], 0))
-
-    for method, use_lsi in [('LogisticRegression', False)]:
-
-        print('='*80, '\n', ' '*10,
-              method, " + LSI" if use_lsi else ' ', '\n', '='*80)
-        parent_id = dsid
-
-        url = BASE_URL + '/categorization/'
-        print(" POST", url)
-        print(' Training...')
-
-        res = requests.post(url,
-                            json={'parent_id': parent_id,
-                                  'data': input_ds['training_set'],
-                                  'method': method,  # one of "LinearSVC", "LogisticRegression", 'xgboost'
-                                  'training_scores': True
-                                  }).json()
-
-        mid = res['id']
-        print("     => model id = {}".format(mid))
-        print('    => Training scores: MAP = {average_precision:.3f}, ROC-AUC = {roc_auc:.3f}, recall @20%: {recall_at_20p:.3f} '.format(**res['training_scores']))
-
-        print("\n3.b. Check the parameters used in the categorization model")
-        url = BASE_URL + '/categorization/{}'.format(mid)
-        print(" GET", url)
-        res = requests.get(url).json()
-
-        print('\n'.join(['     - {}: {}'.format(key, val)
-              for key, val in res.items() if key not in ['index', 'category']]))
-
-        print("\n3.c Categorize the complete dataset with this model")
-        url = BASE_URL + '/categorization/{}/predict'.format(mid)
-        print(" GET", url)
-        res = requests.get(url, json={'subset': 'test'}).json()
-
-        data = []
-        for row in res['data']:
-            nrow = {'document_id': row['document_id'],
-                    'category': row['scores'][0]['category'],
-                    'score': row['scores'][0]['score']}
-            if method == 'NearestNeighbor':
-                nrow['nearest_document_id'] = row['scores'][0]['document_id']
-            data.append(nrow)
-
-        df = pd.DataFrame(data).set_index('document_id')
-        print(df.iloc[:10])
-
-    # 4. Cleaning
-    print("\n5.a Delete the extracted features (and LSI decomposition)")
-    url = BASE_URL + '/feature-extraction/{}'.format(dsid)
-    print(" DELETE", url)
-    requests.delete(url)
+# 4. Cleaning
+print("\n5.a Delete the extracted features (and LSI decomposition)")
+url = BASE_URL + '/feature-extraction/{}'.format(dsid)
+print(" DELETE", url)
+requests.delete(url)

--- a/benchmarks/ingestion.py
+++ b/benchmarks/ingestion.py
@@ -1,0 +1,143 @@
+"""
+Categorization Example [REST API]
+---------------------------------
+
+An example to illustrate binary categorizaiton with FreeDiscovery
+"""
+
+from __future__ import print_function
+
+from time import time, sleep
+from pathlib import Path
+import os.path
+from multiprocessing import Process
+import requests
+import pandas as pd
+
+pd.options.display.float_format = '{:,.3f}'.format
+pd.options.display.expand_frame_repr = False
+
+dataset_name = "treclegal09_37k_subset"     # see list of available datasets
+
+BASE_URL = "http://localhost:5001/api/v0"  # FreeDiscovery server URL
+
+ingestion_method = 'file_path'
+#ingestion_method = 'content'
+
+if __name__ == '__main__':
+
+    print(" 0. Load the example dataset")
+    url = BASE_URL + '/example-dataset/{}'.format(dataset_name)
+    print(" GET", url)
+    input_ds = requests.get(url).json()
+
+    data_dir = input_ds['metadata']['data_dir']
+    dataset_definition = []
+    for row in input_ds['dataset']:
+        dd_row = {'document_id': row['document_id']}
+        if ingestion_method == 'file_path':
+            dd_row['file_path'] = os.path.join(data_dir, row['file_path'])
+            dataset_definition.append(dd_row)
+        elif ingestion_method == 'content':
+            with Path(data_dir, row['file_path']).open('rt') as fh:
+                try:
+                    dd_row['content'] = fh.read()
+                    dataset_definition.append(dd_row)
+                except UnicodeDecodeError:
+                    print(Path(data_dir, row['file_path']), ' failed!')
+        else:
+            raise ValueError
+    # create a custom dataset definition for ingestion
+
+    # 1. Feature extraction
+
+    print("\n1.a Load dataset and initalize feature extraction")
+    url = BASE_URL + '/feature-extraction'
+    print(" POST", url)
+    res = requests.post(url, json={'max_df': 0.6, 'preprocess': ['emails_ignore_header']}).json()
+
+    dsid = res['id']
+    print("   => received {}".format(list(res.keys())))
+    print("   => dsid = {}".format(dsid))
+
+    print("\n1.b Start feature extraction (in the background)")
+
+    # Make this call in a background process (there should be a better way of doing it)
+    url = BASE_URL+'/feature-extraction/{}'.format(dsid)
+    print(" POST", url)
+    t0 = time()
+    for i in range(0, len(dataset_definition), 8000):
+        res = requests.post(url, json={'dataset_definition': dataset_definition[i:i + 8000],
+                                       'vectorize': False})
+
+    print('     ... files ingested in {:.1f} s'.format((time() - t0)))
+    t1 = time()
+    res = requests.post(url, json={'vectorize': True})
+    print('     ... files vectorized in {:.1f} s'.format((time() - t0)))
+
+    print("\n1.d. check the parameters of the extracted features")
+    url = BASE_URL + '/feature-extraction/{}'.format(dsid)
+    print(' GET', url)
+    res = requests.get(url).json()
+
+    print('\n'.join(['     - {}: {}'.format(key, val)
+          for key, val in res.items() if "filenames" not in key]))
+
+    # 3. Document categorization
+
+    print("\n3.a. Train the categorization model")
+    print("   {} positive, {} negative files".format(
+          pd.DataFrame(input_ds['training_set'])
+            .groupby('category').count()['document_id'], 0))
+
+    for method, use_lsi in [('LogisticRegression', False)]:
+
+        print('='*80, '\n', ' '*10,
+              method, " + LSI" if use_lsi else ' ', '\n', '='*80)
+        parent_id = dsid
+
+        url = BASE_URL + '/categorization/'
+        print(" POST", url)
+        print(' Training...')
+
+        res = requests.post(url,
+                            json={'parent_id': parent_id,
+                                  'data': input_ds['training_set'],
+                                  'method': method,  # one of "LinearSVC", "LogisticRegression", 'xgboost'
+                                  'training_scores': True
+                                  }).json()
+
+        mid = res['id']
+        print("     => model id = {}".format(mid))
+        print('    => Training scores: MAP = {average_precision:.3f}, ROC-AUC = {roc_auc:.3f}, recall @20%: {recall_at_20p:.3f} '.format(**res['training_scores']))
+
+        print("\n3.b. Check the parameters used in the categorization model")
+        url = BASE_URL + '/categorization/{}'.format(mid)
+        print(" GET", url)
+        res = requests.get(url).json()
+
+        print('\n'.join(['     - {}: {}'.format(key, val)
+              for key, val in res.items() if key not in ['index', 'category']]))
+
+        print("\n3.c Categorize the complete dataset with this model")
+        url = BASE_URL + '/categorization/{}/predict'.format(mid)
+        print(" GET", url)
+        res = requests.get(url, json={'subset': 'test'}).json()
+
+        data = []
+        for row in res['data']:
+            nrow = {'document_id': row['document_id'],
+                    'category': row['scores'][0]['category'],
+                    'score': row['scores'][0]['score']}
+            if method == 'NearestNeighbor':
+                nrow['nearest_document_id'] = row['scores'][0]['document_id']
+            data.append(nrow)
+
+        df = pd.DataFrame(data).set_index('document_id')
+        print(df.iloc[:10])
+
+    # 4. Cleaning
+    print("\n5.a Delete the extracted features (and LSI decomposition)")
+    url = BASE_URL + '/feature-extraction/{}'.format(dsid)
+    print(" DELETE", url)
+    requests.delete(url)

--- a/freediscovery/categorization.py
+++ b/freediscovery/categorization.py
@@ -79,7 +79,7 @@ class _CategorizerWrapper(_BaseWrapper):
     _wrapper_type = "categorizer"
 
     def __init__(self, cache_dir='/tmp/',  parent_id=None, mid=None,
-                 cv_scoring='roc_auc', cv_n_folds=3):
+                 cv_scoring='roc_auc', cv_n_folds=3, random_state=None):
 
         super(_CategorizerWrapper, self).__init__(cache_dir=cache_dir,
                                           parent_id=parent_id,
@@ -89,9 +89,10 @@ class _CategorizerWrapper(_BaseWrapper):
             self.le = joblib.load(str(self.model_dir / mid / 'label_encoder'))
         self.cv_scoring = cv_scoring
         self.cv_n_folds = cv_n_folds
+        self.random_state = random_state
 
     @staticmethod
-    def _build_estimator(Y_train, method, cv, cv_scoring, cv_n_folds, **options):
+    def _build_estimator(Y_train, method, cv, cv_scoring, cv_n_folds, random_state=None, **options):
         if cv:
             #from sklearn.cross_validation import StratifiedKFold
             #cv_obj = StratifiedKFold(n_splits=cv_n_folds, shuffle=False)
@@ -104,7 +105,7 @@ class _CategorizerWrapper(_BaseWrapper):
         if method == 'LinearSVC':
             from sklearn.svm import LinearSVC
             if cv is None:
-                cmod = LinearSVC(**options)
+                cmod = LinearSVC(random_state=random_state, **options)
             else:
                 try:
                     from freediscovery_extra import make_linearsvc_cv_model
@@ -114,7 +115,7 @@ class _CategorizerWrapper(_BaseWrapper):
         elif method == 'LogisticRegression':
             from sklearn.linear_model import LogisticRegression
             if cv is None:
-                cmod = LogisticRegression(**options)
+                cmod = LogisticRegression(random_state=random_state, **options)
             else:
                 try:
                     from freediscovery_extra import make_logregr_cv_model
@@ -148,7 +149,8 @@ class _CategorizerWrapper(_BaseWrapper):
             from sklearn.neural_network import MLPClassifier
             cmod = MLPClassifier(solver='adam', hidden_layer_sizes=10,
                                  max_iter=200, activation='identity',
-                                 verbose=0)
+                                 verbose=0,
+                                 random_state=random_state)
         else:
             raise WrongParameter('Method {} not implemented!'.format(method))
         return cmod

--- a/freediscovery/ingestion.py
+++ b/freediscovery/ingestion.py
@@ -379,8 +379,13 @@ class DocumentIndex(object):
 
     @staticmethod
     def _detect_data_dir(filenames):
-        data_dir = os.path.commonprefix(filenames)
-        data_dir = os.path.normpath(data_dir)
+        if len(filenames) > 1:
+            data_dir = os.path.commonprefix(filenames)
+            data_dir = os.path.normpath(data_dir)
+        elif len(filenames) == 1:
+            data_dir = os.path.dirname(filenames[0])
+        else:
+            raise ValueError('Provided list of filenames is empty!')
 
         if os.path.exists(data_dir):
             return data_dir

--- a/freediscovery/lsi.py
+++ b/freediscovery/lsi.py
@@ -66,10 +66,11 @@ class _LSIWrapper(_BaseWrapper):
     _wrapper_type = "lsi"
 
     def __init__(self, cache_dir='/tmp/', parent_id=None,
-                 mid=None, verbose=False):
+                 mid=None, verbose=False, random_state=None):
 
         super(_LSIWrapper, self).__init__(cache_dir=cache_dir,
                                           parent_id=parent_id, mid=mid)
+        self.random_state = random_state
 
     def _load_features(self):
         mid_dir = self.fe.dsid_dir / self._wrapper_type / self.mid
@@ -114,7 +115,7 @@ class _LSIWrapper(_BaseWrapper):
         n_components_opt = _compute_lsi_dimensionality(n_components, *ds.shape,
                                                        alpha=alpha)
         svd = _TruncatedSVD_LSI(n_components=n_components_opt,
-                                n_iter=n_iter)
+                                n_iter=n_iter, random_state=self.random_state)
         lsi = svd
         lsi.fit(ds)
 

--- a/freediscovery/preprocessing.py
+++ b/freediscovery/preprocessing.py
@@ -2,11 +2,10 @@ import re
 
 
 
-def emails_ignore_header(line):
+def emails_ignore_header(doc):
     """ Skip irrelevant email header fields """
-    if re.match('(?i)^\s*(?:To|From|Date|To|Cc|Sent):\s', line):
-        return ''
-    else:
-        return line
+    doc  = '\n'.join([line for line in doc.splitlines()
+                      if not line.strip().startswith(('To:','From:','Date:', 'To:','Cc:','Sent:'))])
+    return doc
 
 processing_filters = {'emails_ignore_header': emails_ignore_header}

--- a/freediscovery/preprocessing.py
+++ b/freediscovery/preprocessing.py
@@ -1,0 +1,12 @@
+import re
+
+
+
+def emails_ignore_header(line):
+    """ Skip irrelevant email header fields """
+    if re.match('(?i)^\s*(?:To|From|Date|To|Cc|Sent):\s', line):
+        return ''
+    else:
+        return line
+
+processing_filters = {'emails_ignore_header': emails_ignore_header}

--- a/freediscovery/server/app.py
+++ b/freediscovery/server/app.py
@@ -108,6 +108,7 @@ def fd_app(cache_dir, config=None):
                              ]:
         # monkeypatching, not great
         resource_el._cache_dir = cache_dir
+        resource_el._random_seed = os.environ.get('FREEDISCOVERY_RANDOM_SEED', 42)
         resource_el.methods = ['GET', 'POST', 'DELETE']
         #api.add_resource(resource_el, '/api/v0' + url, strict_slashes=False)
 

--- a/freediscovery/server/resources.py
+++ b/freediscovery/server/resources.py
@@ -284,7 +284,8 @@ class LsiApi(Resource):
     @marshal_with(LsiParsSchema(many=True))
     def get(self, **args):
         parent_id = args['parent_id']
-        lsi = _LSIWrapper(cache_dir=self._cache_dir, parent_id=parent_id)
+        lsi = _LSIWrapper(cache_dir=self._cache_dir, parent_id=parent_id,
+                          random_state=self._random_seed)
         return lsi.list_models()
 
     @doc(description=dedent("""
@@ -307,7 +308,8 @@ class LsiApi(Resource):
     def post(self, **args):
         parent_id = args['parent_id']
         del args['parent_id']
-        lsi = _LSIWrapper(cache_dir=self._cache_dir, parent_id=parent_id)
+        lsi = _LSIWrapper(cache_dir=self._cache_dir, parent_id=parent_id,
+                          random_state=self._random_seed)
         _, explained_variance = lsi.fit_transform(**args)
         return {'id': lsi.mid, 'explained_variance': explained_variance}
 
@@ -363,7 +365,8 @@ class ModelsApi(Resource):
     def post(self, **args):
         training_scores = args['training_scores']
         parent_id = args['parent_id']
-        cat = _CategorizerWrapper(self._cache_dir, parent_id=parent_id)
+        cat = _CategorizerWrapper(self._cache_dir, parent_id=parent_id,
+                                  random_state=self._random_seed)
 
         query = pd.DataFrame(args['data'])
         res_q = cat.fe.db_.search(query, drop=False)

--- a/freediscovery/server/resources.py
+++ b/freediscovery/server/resources.py
@@ -124,6 +124,7 @@ class FeaturesApi(Resource):
              - `min_df`: When building the vocabulary ignore terms that have a document frequency strictly lower than the given threshold. This value is ignored when hashing is used.
              - `max_df`: When building the vocabulary ignore terms that have a document frequency strictly higher than the given threshold. This value is ignored when hashing is used.
              - `parse_email_headers`: when documents are emails, attempt to parse the information contained in the header (default: False)
+             - `preprocess`: a list of pre-processing steps to apply before vectorization. A subset of ['emails_ignore_header'], default: [].
             """))
     @use_args(FeaturesParsSchema(strict=True, exclude=('norm', 'data_dir')))
     @marshal_with(IDSchema())

--- a/freediscovery/server/schemas.py
+++ b/freediscovery/server/schemas.py
@@ -83,6 +83,7 @@ class FeaturesParsSchema(Schema):
     min_df = fields.Number(required=False)
     max_df = fields.Number(required=False)
     parse_email_headers = fields.Boolean(missing=False)
+    preprocess = fields.List(fields.Str(), missing=[])
 
 
 class FeaturesSchema(FeaturesParsSchema):

--- a/freediscovery/server/tests/test_ingestion.py
+++ b/freediscovery/server/tests/test_ingestion.py
@@ -66,7 +66,8 @@ def test_get_feature_extraction(app, hashed, use_idf):
                      'n_features': 'int', 'use_idf': 'bool',
                      'binary': 'bool', 'sublinear_tf': 'bool', 'use_hashing': 'bool',
                      'filenames': ['str'], 'max_df': 'float', 'min_df': 'float',
-                     'parse_email_headers': 'bool', 'n_samples_processed': 'int'}
+                     'parse_email_headers': 'bool', 'n_samples_processed': 'int',
+                     'preprocess': []}
 
     assert data['use_hashing'] == hashed
     assert data['sublinear_tf'] == False

--- a/freediscovery/server/tests/test_preprocessing.py
+++ b/freediscovery/server/tests/test_preprocessing.py
@@ -1,0 +1,40 @@
+# -*- coding: utf-8 -*-
+
+import os.path
+from pathlib import Path
+import pickle
+
+import pytest
+import numpy as np
+import pandas as pd
+from numpy.testing import assert_equal, assert_array_equal
+
+from freediscovery.utils import dict2type, sdict_keys
+from .base import (parse_res, V01, app, data_dir,
+                   CACHE_DIR)
+from sklearn.externals import joblib
+
+
+@pytest.mark.parametrize('preprocess', [[],
+                                           ['emails_ignore_header']])
+def test_preprocessing_email_headers(app, preprocess):
+    method = V01 + "/feature-extraction/"
+    data = app.post_check(method, json={"preprocess": preprocess})
+    dsid = data['id']
+    method += dsid
+    app.post_check(method, json={'dataset_definition': [{'file_path': os.path.join(data_dir, '0.7.6.28635.txt')}]})
+
+
+    with (Path(CACHE_DIR) / 'ediscovery_cache' / dsid / 'vectorizer').open('rb') as fh:
+        vectorizer = pickle.load(fh)
+
+
+    pars = app.get_check(method)
+    assert pars['preprocess'] == preprocess
+
+
+    vocabulary = list(vectorizer.vocabulary_.keys())
+    if not preprocess:
+        assert 'baumbach' in vocabulary # a name in the To: header
+    else:
+        assert 'baumbach' not in vocabulary # a name in the To: header

--- a/freediscovery/server/tests/test_search.py
+++ b/freediscovery/server/tests/test_search.py
@@ -194,8 +194,9 @@ def test_search_consistency(app):
     X_tmp = []
     comp_document_id = 2365444
     for document_id in [query_document_id, comp_document_id]:
-        X_tmp.append(os.path.join(ds_pars['data_dir'],
-                                  input_ds.loc[document_id].file_path))
+        with open(os.path.join(ds_pars['data_dir'],
+            input_ds.loc[document_id].file_path), 'rb') as fh:
+            X_tmp.append(fh.read().decode('utf-8'))
     X_tmp = vect.transform(X_tmp)
     X_tmp = lsi_est.transform_lsi_norm(X_tmp)
     assert_allclose(cosine_similarity(X_tmp[[0]], X_tmp[[1]]),

--- a/freediscovery/tests/test_io.py
+++ b/freediscovery/tests/test_io.py
@@ -5,10 +5,10 @@ from __future__ import division
 from __future__ import print_function
 
 import os.path
-from numpy.testing import assert_allclose
+from numpy.testing import assert_allclose, assert_array_equal
 
 from freediscovery.io import (parse_ground_truth_file,
-                              parse_rcv1_smart_tokens)
+                              parse_smart_tokens)
 
 
 def test_parse_ground_truth_file():
@@ -32,12 +32,12 @@ def test_parse_smart_stemmed():
     sunday won race race andret andret rahal bobby lola lola ford ford reynard merced christ benz motor fittipald grand prix finish finish michael win vancouv vancouv indycar indycar
     """)
 
-    res = parse_rcv1_smart_tokens(text)
-    assert list(res.keys()) == ['26187', '26188']
-    assert len(res['26188']) == 28
+    res = parse_smart_tokens(text)
+    assert_array_equal(res.index, [26187, 26188])
+    assert len(res.loc[26188].W.split(' ')) == 28
     res_ref = ['sunday', 'won', 'race', 'race', 'andret', 'andret', 'rahal',
                'bobby', 'lola', 'lola', 'ford', 'ford', 'reynard', 'merced',
                'christ', 'benz', 'motor', 'fittipald', 'grand', 'prix',
                'finish', 'finish', 'michael', 'win', 'vancouv', 'vancouv',
                'indycar', 'indycar']
-    assert res['26188'] == res_ref
+    assert res.loc[26188].W.split(' ') == res_ref

--- a/freediscovery/text.py
+++ b/freediscovery/text.py
@@ -39,11 +39,11 @@ def _preprocess_stream(doc, steps=None):
     """ Apply pre-processing steps """
 
     if steps:
-        doc = doc.splitlines()
+        #doc = doc.splitlines()
         for key in steps:
             func = processing_filters[key]
-            doc = [func(line) for line in doc]
-        doc = '\n'.join(doc)
+            doc = func(doc) #[func(line) for line in doc]
+        #doc = '\n'.join(doc)
 
     return doc
 


### PR DESCRIPTION
This PR adds a mechanism to allow optional pre-processing of documents before vectorizations, via the `preprocess` argument of the `POST /feature-extraction'` endpoint. Included filiters are,
 - ''emails_ignore_headers": allowing to ignore most frequent header fields when processing emails

This  PR  fixes the random_seed for all processing steps that take random state as input, in order to ensure reproducibility. The random seed can be modified with the `FREEDISCOVERY_RANDOM_SEED` environment variable. 

This also improves the parser for the SMART tokenization file format.