### PR TITLE
MAINT Use Marshmallow 2.x

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -27,6 +27,8 @@ dependencies:
     - sleep 20
     # The pipefail is requested to propagate exit code
     - set -o pipefail && cd doc && source activate testenv && make html 2>&1 | tee ~/log.txt
+    # use HTTP for NPM to avoid connection issues
+    - npm config set registry http://registry.npmjs.org/
     - npm install -g bootprint && npm install -g bootprint-openapi
     - cd doc && bootprint openapi http://0.0.0.0:5001/openapi-specs.json openapi-docs && cp -r openapi-docs/ _build/html/
 

--- a/freediscovery/datasets.py
+++ b/freediscovery/datasets.py
@@ -10,7 +10,8 @@ import numpy as np
 import pandas as pd
 import pickle
 
-from freediscovery.externals.keras_data_utils import _get_file, INTERNAL_DATA_DIR
+from freediscovery.externals.keras_data_utils import _get_file
+from freediscovery.externals.keras_data_utils import INTERNAL_DATA_DIR
 
 
 def _normalize_cachedir(cache_dir):
@@ -22,28 +23,36 @@ def _normalize_cachedir(cache_dir):
         cache_dir = os.path.join(cache_dir, "ediscovery_cache")
     return cache_dir
 
-IR_DATASETS = {'treclegal09_2k_subset': {'md5': '8090cc55ac18fe5c4d5d53d82fc767a2',
-                                         'size': 2.8},
-               'treclegal09_20k_subset': {'md5': '43a711897ce724e873bdbc47a374a57e',
-                                          'size': 30},
-               'treclegal09_37k_subset': {'md5': '9fb6b7505871bbaee5a438de3b0f497c',
-                                          'size': 55},
+
+IR_DATASETS = {'treclegal09_2k_subset': {
+                         'md5': '8090cc55ac18fe5c4d5d53d82fc767a2',
+                         'size': 2.8},
+               'treclegal09_20k_subset': {
+                         'md5': '43a711897ce724e873bdbc47a374a57e',
+                         'size': 30},
+               'treclegal09_37k_subset': {
+                         'md5': '9fb6b7505871bbaee5a438de3b0f497c',
+                         'size': 55},
                'legal09int': {'md5': '929a675b981282c01c7212030323789f',
                               'size': 1500,
                               'url': "http://r0h.eu/d/legal09int.tar.gz"},
-               'fedora_ml_3k_subset': {'md5': '09dbb03d13b8e341bd615ce43f2d836b',
-                                       'size': 3},
-               '20_newsgroups_3categories': {'md5': '7e59e10cbd824190f3f1fa82285c7865',
-                                             'size': 3,
-                                             'url': os.path.join(INTERNAL_DATA_DIR, '20_newsgroups_3categories.pkl.xz')
+               'fedora_ml_3k_subset': {
+                          'md5': '09dbb03d13b8e341bd615ce43f2d836b',
+                          'size': 3},
+               '20_newsgroups_3categories': {
+                          'md5': '7e59e10cbd824190f3f1fa82285c7865',
+                          'size': 3,
+                          'url': os.path.join(INTERNAL_DATA_DIR, '20_newsgroups_3categories.pkl.xz')  # noqa
                                              },
-               '20_newsgroups_micro': {'md5': 'f6ec5e8669ebde1efa11148096c7cc0c',
-                                       'size': 3,
-                                       'url': os.path.join(INTERNAL_DATA_DIR, '20_newsgroups_micro.pkl')
+               '20_newsgroups_micro': {
+                          'md5': 'f6ec5e8669ebde1efa11148096c7cc0c',
+                          'size': 3,
+                          'url': os.path.join(INTERNAL_DATA_DIR, '20_newsgroups_micro.pkl')  # noqa
                                        },
-               '20_newsgroups': {'md5': 'f6ec5e8669ebde1efa11148096c7cc0c',
-                                     'size': 3,
-                                     'url': 'http://qwone.com/~jason/20Newsgroups/20news-19997.tar.gz'},
+               '20_newsgroups': {
+                          'md5': 'f6ec5e8669ebde1efa11148096c7cc0c',
+                          'size': 3,
+                          'url': 'http://qwone.com/~jason/20Newsgroups/20news-19997.tar.gz'},  # noqa
                }
 
 
@@ -63,7 +72,8 @@ def _load_erdm_ground_truth(outdir):
 
     if platform.system() == 'Windows':
         relevant_files = [el.replace('/', '\\') for el in relevant_files]
-        non_relevant_files = [el.replace('/', '\\') for el in non_relevant_files]
+        non_relevant_files = [el.replace('/', '\\')
+                              for el in non_relevant_files]
     return non_relevant_files, relevant_files
 
 
@@ -170,7 +180,7 @@ def load_dataset(name='20_newsgroups_3categories', cache_dir='/tmp',
         if '20_newsgroups_' in name:
             os.mkdir(outdir)
             for idx, doc in enumerate(twenty_news.data):
-                with open(os.path.join(outdir, '{:05}.txt'.format(idx)), 'wt') as fh:
+                with open(os.path.join(outdir, '{:05}.txt'.format(idx)), 'wt') as fh:  # noqa
                     fh.write(doc)
         else:
             outdir = _get_file(str(fname),
@@ -205,7 +215,7 @@ def load_dataset(name='20_newsgroups_3categories', cache_dir='/tmp',
                                           positive_files + negative_files}))
             di.data.loc[res.internal_id.values, 'is_train'] = True
     elif '20_newsgroups_' in name:
-        di.data['category'] = np.array(twenty_news.target_names)[twenty_news.target]
+        di.data['category'] = np.array(twenty_news.target_names)[twenty_news.target]  # noqa
         di.data['is_train'] = ['-train' in el for el in twenty_news.filenames]
 
     if categories is not None and has_categories:

--- a/freediscovery/engine/tests/test_ingestion.py
+++ b/freediscovery/engine/tests/test_ingestion.py
@@ -125,7 +125,8 @@ def test_ingestion_render(return_file_path):
     assert sorted(rd.keys()) == sorted(['internal_id', 'document_id', 'a'])
     assert_frame_equal(pd.DataFrame(rd),
                        pd.DataFrame([{'a': 2, 'internal_id': 3, 'document_id': 9},
-                                     {'a': 4, 'internal_id': 1, 'document_id': 1}]))
+                                     {'a': 4, 'internal_id': 1, 'document_id': 1}]),
+                       check_like=True)
 
     rd = dbi.render_list()
     assert sorted(rd.keys()) == sorted(['internal_id', 'document_id'])

--- a/freediscovery/feature_weighting.py
+++ b/freediscovery/feature_weighting.py
@@ -135,7 +135,7 @@ class SmartTfidfTransformer(BaseEstimator, TransformerMixin):
     .. [Singhal1996] A. Singhal, C. Buckley, and M. Mitra.
        `"Pivoted document length normalization."
        <https://ecommons.cornell.edu/bitstream/handle/1813/7217/95-1560.pdf?sequence=1>`_ , 1996
-    """
+    """ # noqa
     def __init__(self, weighting='nsc', norm_alpha=0.75, norm_pivot=None,
                  compute_df=False, copy=True):
         _validate_smart_notation(weighting)
@@ -305,7 +305,7 @@ def _smart_tfidf(tf, weighting, df=None, df_n_samples=None, norm_alpha=0.75,
     .. [Singhal1996] A. Singhal, C. Buckley, and M. Mitra.
        `"Pivoted document length normalization."
        <https://ecommons.cornell.edu/bitstream/handle/1813/7217/95-1560.pdf?sequence=1>`_ , 1996
-    """
+    """  # noqa
 
     tf = check_array(tf, ['csr'])
     if (df is None) != (df_n_samples is None):
@@ -376,7 +376,7 @@ def _smart_tfidf(tf, weighting, df=None, df_n_samples=None, norm_alpha=0.75,
         elif scheme_d == 'p':
             with warnings.catch_warnings():
                 warnings.filterwarnings("ignore",
-                                        message="divide by zero encountered in log",
+                                        message="divide by zero encountered in log",  # noqa
                                         category=RuntimeWarning)
                 idf = np.log((float(df_n_samples) - df)/df)
         elif scheme_d == 'd':

--- a/requirements_engine.txt
+++ b/requirements_engine.txt
@@ -6,6 +6,6 @@ nltk>=3.2.1
 pytest>=3.0.1
 flask>=0.12.0         # web libraries
 requests>=2.7.0
-marshmallow>=2.12.2
+marshmallow>=2.12.2,<2.99
 webargs>=1.5.3
 flask-apispec>=0.3.2


### PR DESCRIPTION
Marshmallow 3 introduces [breaking changes](http://marshmallow.readthedocs.io/en/latest/upgrading.html#upgrading-to-3-0) and [is still in beta](https://pypi.org/project/marshmallow/#history). This PR ensures that the installed version of marshmallow is 2.x. Also adds some PEP8 improvements.